### PR TITLE
xmltv.py: Fix issue with `xdetails=true` and `xdesc=false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install gracenote2epg[full]
 pip install gracenote2epg
 
 # Alternative: Install from GitHub
-pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.3"
+pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.4"
 ```
 
 ### 📦 Development Installation

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Country**: Use actual country of origin, if unavailable discard
 ### Optimisations
 - **Parallel Downloads**: To help significantly reduce download duration
+   Ref.: https://github.com/th0ma7/gracenote2epg/pull/2
+
+## [1.5.4] - 2025-08-27
+
+### Fixed
+- **Extended Details**: Fixed issue where `xdetails=true` with `xdesc=false` incorrectly omitted credits, extended categories, and series images.
 
 ## [1.5.3] - 2025-08-25
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,8 +34,8 @@ gracenote2epg auto-detects your system and uses appropriate directories:
   <setting id="stitle">false</setting>                         <!-- Safe titles (replace special chars) -->
 
   <!-- Extended details and language detection -->
-  <setting id="xdetails">true</setting>                        <!-- Download series details + enhanced metadata -->
-  <setting id="xdesc">true</setting>                           <!-- Use enhanced descriptions (see below) -->
+  <setting id="xdetails">true</setting>                        <!-- Use extended data (credits, images, categories) -->
+  <setting id="xdesc">true</setting>                           <!-- Use extended descriptions + enhanced info -->
   <setting id="langdetect">true</setting>                      <!-- Enable automatic language detection -->
 
   <!-- Display options -->
@@ -117,38 +117,29 @@ tv_grab_gracenote2epg --show-lineup --postal J3B1M4 --debug
 <setting id="days">7</setting>         <!-- 7 days of guide data -->
 ```
 
-### Extended Details
+### Extended Details Configuration
 
-#### xdetails
-**Download series details** from the API for enhanced metadata
-```xml
-<setting id="xdetails">true</setting>  <!-- Enable extended data download -->
-```
+#### Understanding xdetails vs xdesc
 
-When enabled:
-- Downloads detailed series information from the API
-- Adds cast and crew with photos
-- Includes original air dates
-- Provides enhanced ratings (MPAA system)
-- Adds technical details (language, country, video/audio info)
-- Enables extended series descriptions (if available)
+These two settings work **independently** to control different aspects of extended functionality:
 
-#### xdesc  
-**Description mode and enhancements** - Controls BOTH description (e.g. extended if available) AND additional info (e.g. `• new | live | CC`)
-```xml
-<setting id="xdesc">true</setting>     <!-- Use enhanced descriptions with additional info -->
-<setting id="xdesc">false</setting>    <!-- Use basic descriptions WITHOUT additional info -->
-```
+**Automatic API Download Logic**: API downloads occur when **either** `xdetails=true` **OR** `xdesc=true`
+- `xdetails=true` triggers downloads and uses extended metadata (credits, images, categories)
+- `xdesc=true` triggers downloads for enhanced description (year, rating, flags, original air dates)
 
-When `xdesc=true`:
-- Uses extended series descriptions when available (falls back to basic episode description if extended not available)
-- **ADDS enhanced info** to descriptions: year, rating, NEW/LIVE/PREMIERE flags, CC/HD tags
+However, the **usage** of downloaded data depends on the specific setting:
 
-When `xdesc=false`:
-- Uses basic episode descriptions from the default guide
-- **NO additional info added** - descriptions are displayed exactly as received
-- Clean, simple descriptions without any enhancements
-- Ideal for users who prefer minimal descriptions or when Kodi/Plex adds its own metadata
+### Configuration Matrix
+
+| xdetails | xdesc | API Downloads | Credits | Extended Categories | Series Images | Description Enhancement |
+|----------|-------|---------------|---------|-------------------|---------------|----------------------|
+| `false`  | `false` | ❌ No         | ❌ No   | ❌ Basic only      | ❌ Episode only | ❌ Basic guide text  |
+| `false`  | `true`  | ✅ Yes*       | ❌ No   | ❌ Basic only      | ❌ Episode only | ✅ Basic + enhancements* |
+| `true`   | `false` | ✅ Yes        | ✅ Yes  | ✅ Extended        | ✅ Series     | ❌ Basic guide text  |
+| `true`   | `true`  | ✅ Yes        | ✅ Yes  | ✅ Extended        | ✅ Series     | ✅ Extended + enhancements |
+
+*API downloads automatically triggered when `xdesc=true` to gather enhancement data (year, rating, flags, original air dates)
+*Enhancement includes: year, rating, flags (NEW/LIVE/PREMIERE), CC/HD tags
 
 **Examples of description differences**:
 
@@ -157,11 +148,11 @@ xdesc=true:  "A detective investigates a mysterious case. • 2023 | Rated: TV-1
 xdesc=false: "A detective investigates a mysterious case."
 ```
 
-**Interaction with xdetails**:
-- `xdetails=false, xdesc=false`: Basic descriptions, no downloads, no enhancements
-- `xdetails=false, xdesc=true`: Basic descriptions WITH enhancements (year, flags, etc.)
-- `xdetails=true, xdesc=false`: Downloads extended data but uses basic descriptions without enhancements
-- `xdetails=true, xdesc=true`: Full functionality - extended descriptions with all enhancements
+**Use Cases**:
+- **`xdetails=true, xdesc=false`**: Want full metadata (credits, images, categories) but clean, simple descriptions
+- **`xdetails=false, xdesc=true`**: Want enhanced descriptions only (API downloads occur for enhancement data, but no credits/extended categories/series images)
+- **`xdetails=true, xdesc=true`**: Full functionality (recommended for most users)
+- **`xdetails=false, xdesc=false`**: Minimal setup (fastest, lowest bandwidth, no API downloads)
 
 #### langdetect
 **Automatic language detection** (requires `langdetect` library)
@@ -300,7 +291,7 @@ Same format as `relogs` - controls how long to keep XMLTV backup files.
   <!-- Basic guide settings -->
   <setting id="zipcode">92101</setting>
   <setting id="lineupid">auto</setting>
-  <setting id="days">7</setting>
+  <setting id="days">14</setting>
 
   <!-- Extended features -->
   <setting id="xdetails">true</setting>
@@ -308,57 +299,11 @@ Same format as `relogs` - controls how long to keep XMLTV backup files.
   <setting id="langdetect">true</setting>
 
   <!-- Cache and retention -->
-  <setting id="redays">7</setting>
+  <setting id="redays">14</setting>
   <setting id="refresh">48</setting>
   <setting id="logrotate">true</setting>
   <setting id="relogs">30</setting>
   <setting id="rexmltv">7</setting>
-</settings>
-```
-
-### Minimal Descriptions Setup
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<settings version="5">
-  <!-- Basic guide settings -->
-  <setting id="zipcode">92101</setting>
-  <setting id="lineupid">auto</setting>
-  <setting id="days">7</setting>
-
-  <!-- Minimal descriptions without enhancements -->
-  <setting id="xdetails">false</setting>
-  <setting id="xdesc">false</setting>
-  <setting id="langdetect">false</setting>
-
-  <!-- Cache and retention -->
-  <setting id="redays">7</setting>
-  <setting id="refresh">48</setting>
-  <setting id="logrotate">true</setting>
-  <setting id="relogs">30</setting>
-  <setting id="rexmltv">7</setting>
-</settings>
-```
-
-### High-Volume Server
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<settings version="5">
-  <!-- Extended cache for stability -->
-  <setting id="zipcode">90210</setting>
-  <setting id="lineupid">auto</setting>
-  <setting id="days">14</setting>
-
-  <!-- Full features -->
-  <setting id="xdetails">true</setting>
-  <setting id="xdesc">true</setting>
-  <setting id="langdetect">true</setting>
-  
-  <!-- Cache and retention -->
-  <setting id="redays">21</setting>
-  <setting id="refresh">24</setting>
-  <setting id="logrotate">daily</setting>
-  <setting id="relogs">quarterly</setting>
-  <setting id="rexmltv">monthly</setting>
 </settings>
 ```
 
@@ -450,20 +395,6 @@ grep -A 20 "Configuration values processed" ~/gracenote2epg/log/gracenote2epg.lo
 ## Configuration Migration
 
 gracenote2epg automatically migrates from older configuration formats:
-
-### Legacy Settings (Automatically Migrated)
-```xml
-<!-- Old format (still works) -->
-<setting id="auto_lineup">true</setting>
-<setting id="lineupcode">OTA</setting>
-<setting id="lineup">CAN-OTAJ3B1M4</setting>
-<setting id="device">-</setting>
-
-<!-- Migrated to new format -->
-<setting id="lineupid">auto</setting>
-```
-
-### Backup and Migration
 - Automatic backup of old configuration created
 - Migration messages logged at INFO level
 - New configuration format provides cleaner organization

--- a/docs/development.md
+++ b/docs/development.md
@@ -284,7 +284,7 @@ The project uses a centralized version management system:
 # gracenote2epg/__init__.py
 
 # Example:
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 
 # setup.py will automatically pick up the new version
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,10 +24,10 @@ pip install gracenote2epg[translations]  # Translation support only
 #### Latest Stable Release
 ```bash
 # Install latest stable release from GitHub
-pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.3"
+pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.4"
 
 # Basic installation from GitHub
-pip install "gracenote2epg @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.3"
+pip install "gracenote2epg @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.4"
 ```
 
 #### Latest Development Version
@@ -51,13 +51,13 @@ pip install .        # Basic installation
 ### Method 4: Manual Installation (Source Distribution)
 ```bash
 # Download source from GitHub releases
-wget https://github.com/th0ma7/gracenote2epg/archive/v1.5.3.tar.gz -O gracenote2epg-1.5.3.tar.gz
+wget https://github.com/th0ma7/gracenote2epg/archive/v1.5.4.tar.gz -O gracenote2epg-1.5.4.tar.gz
 
 # Install into /usr/local/
-sudo tar -xzf gracenote2epg-1.5.3.tar.gz -C /usr/local/
+sudo tar -xzf gracenote2epg-1.5.4.tar.gz -C /usr/local/
 
 # Create a generic gracenote2epg symbolic link
-sudo ln -sf /usr/local/gracenote2epg-1.5.3 /usr/local/gracenote2epg
+sudo ln -sf /usr/local/gracenote2epg-1.5.4 /usr/local/gracenote2epg
 
 # Make tv_grab_gracenote2epg available in /usr/local/bin
 sudo ln -sf /usr/local/gracenote2epg/tv_grab_gracenote2epg /usr/local/bin
@@ -119,6 +119,9 @@ tv_grab_gracenote2epg --version
 # Install gracenote2epg from PyPI (recommended) in TVheadend environment
 sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install gracenote2epg[full]'
 
+# Install a specific version of gracenote2epg from Pypi in TVheadend environment
+sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full]==1.5.4"'
+
 # Install latest git snapshot
 sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git"'
 
@@ -166,7 +169,7 @@ python -m gracenote2epg --version    # Module execution
 ```bash
 # Check if package is installed
 pip list | grep gracenote2epg
-# Expected output: gracenote2epg    1.5.3
+# Expected output: gracenote2epg    1.5.4
 
 # Check version
 tv_grab_gracenote2epg --version

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 


### PR DESCRIPTION
Fixed issue where `xdetails=true` with `xdesc=false` incorrectly omitted credits, extended categories, and series images.