### PR TITLE
Configurable image source (<imagesources>) + config schema v6

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,15 @@ with no change to the generated guide.
   subdirectory, keeping the cache root limited to guide blocks for easier
   inspection. Legacy flat caches are migrated automatically on first run (no
   re-download).
+- **Richer program metadata**: crew (directors/writers/producers) is now
+  included and credits are emitted for TV series, not just movies; credits are
+  ordered by billing `priority`. Typed `<image type="poster|backdrop|still">`
+  elements (DTD-valid) are emitted in addition to `<icon>`, including the
+  previously-unused background image. Per-episode synopsis is preferred over the
+  generic series description, and `displayRating` fills a missing guide rating.
+- **Configurable image source**: a new `<imagesources>` config block selects the
+  image host (the first `enabled` source). Mirror hosts serve the same images;
+  the default is `tmsimg.fancybits.co` since `www.tvtv.ca` is rate-limited.
 
 ### Fixed
 - **Timezone offset**: XMLTV times now always carry a standard signed `±HHMM`
@@ -33,6 +42,9 @@ with no change to the generated guide.
   Behaviour verified byte-for-byte identical against the pre-refactor output.
 - **Geographic resolution is now built in**: postal/ZIP → city/province uses a
   small bundled GeoNames dataset read with the standard library.
+- **Config schema version 6**: introduces the `<imagesources>` block. Version-5
+  configs are upgraded automatically on the next run (a backup is written and the
+  block is injected with defaults).
 
 ### Removed
 - **`pgeocode` dependency** (and its transitive `pandas`/`numpy` chain), which

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ gracenote2epg auto-detects your system and uses appropriate directories:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="5">
+<settings version="6">
   <!-- Basic guide settings -->
   <setting id="zipcode">92101</setting>                        <!-- US ZIP or Canadian postal code -->
   <setting id="lineupid">auto</setting>                        <!-- Lineup configuration -->
@@ -57,8 +57,39 @@ gracenote2epg auto-detects your system and uses appropriate directories:
   <setting id="logrotate">true</setting>                       <!-- Log rotation: true(daily)|false|daily|weekly|monthly -->
   <setting id="relogs">30</setting>                            <!-- Log retention: days(number) or weekly|monthly|quarterly -->
   <setting id="rexmltv">7</setting>                            <!-- XMLTV backup retention: days(number) or weekly|monthly|quarterly -->
+
+  <!-- Image source host (first 'enabled' is used) -->
+  <imagesources>
+    <source status="enabled">https://tmsimg.fancybits.co/assets</source>
+    <source status="disabled">https://www.tvtv.ca/gn/pi/assets</source>
+    <source status="disabled">https://zap2it.tmsimg.com/assets</source>
+    <source status="disabled">https://dshm.tmsimg.com/assets</source>
+  </imagesources>
 </settings>
 ```
+
+> **Schema version 6**: the `<imagesources>` block was added in version 6.
+> Existing version-5 configs are upgraded automatically on the next run (a
+> backup is written and the block is injected with defaults).
+
+## Image Source
+
+Program and cast/crew images are referenced by their Gracenote/TMS asset code,
+which several mirror hosts serve identically. The `<imagesources>` block selects
+which host to write into the guide; the **first `enabled` source wins**. Switch
+host by toggling `status` (`enabled` / `disabled`) — no need to retype URLs.
+
+```xml
+<imagesources>
+  <source status="enabled">https://tmsimg.fancybits.co/assets</source>
+  <source status="disabled">https://www.tvtv.ca/gn/pi/assets</source>
+</imagesources>
+```
+
+- Default host is `tmsimg.fancybits.co` (the `www.tvtv.ca` host is rate-limited).
+- You may add your own full base URL as a `<source>`.
+- This only affects the image URLs written to the XMLTV; it has no effect on
+  which channels/programmes are downloaded.
 
 ## Required Settings
 
@@ -287,7 +318,7 @@ Same format as `relogs` - controls how long to keep XMLTV backup files.
 ### Standard Home Setup
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="5">
+<settings version="6">
   <!-- Basic guide settings -->
   <setting id="zipcode">92101</setting>
   <setting id="lineupid">auto</setting>
@@ -310,7 +341,7 @@ Same format as `relogs` - controls how long to keep XMLTV backup files.
 ### Resource-Limited System
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="5">
+<settings version="6">
   <!-- Minimal resource usage -->
   <setting id="zipcode">J3B1M4</setting>
   <setting id="lineupid">auto</setting>
@@ -333,7 +364,7 @@ Same format as `relogs` - controls how long to keep XMLTV backup files.
 ### Development/Testing
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="5">
+<settings version="6">
   <!-- Testing configuration -->
   <setting id="zipcode">92101</setting>
   <setting id="lineupid">auto</setting>

--- a/docs/lineup-configuration.md
+++ b/docs/lineup-configuration.md
@@ -288,7 +288,7 @@ tv_grab_gracenote2epg --days 1 --zip 90210 --console
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="5">
+<settings version="6">
   <!-- Basic guide settings -->
   <setting id="days">2</setting>
   <setting id="zipcode">92101</setting>                        <!-- Your postal/ZIP code -->

--- a/docs/program-metadata.md
+++ b/docs/program-metadata.md
@@ -80,11 +80,13 @@ consumers that only read `<icon>`. Application-level support for `<image>`
    generic series description for episodic `<desc>`.
 4. Optional: credit `priority` ordering, `displayRating`.
 
-## Future: configurable image source (separate PR)
+## Configurable image source
 
-`tvtv.ca` (the current host) rate-limits image serving. The image **codes**
-(`pNNNNN_x_hN_xx`) are TMS asset IDs served identically by several mirror
-hosts, so only the base URL needs to change:
+`tvtv.ca` rate-limits image serving. The image **codes** (`pNNNNN_x_hN_xx`) are
+TMS asset IDs served identically by several mirror hosts, so only the base URL
+changes. This is now configurable via an `<imagesources>` block in the config
+(see [configuration](configuration.md)); the first `enabled` source is used and
+the default is the `fancybits` mirror. Known hosts:
 
 | Base URL | Notes |
 |---|---|

--- a/docs/tvheadend.md
+++ b/docs/tvheadend.md
@@ -36,7 +36,7 @@ Configure gracenote2epg for optimal TVheadend integration. Below is the essentia
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="5">
+<settings version="6">
   <!-- Basic guide settings -->
   <setting id="zipcode">92101</setting>
   <setting id="lineupid">auto</setting>

--- a/gracenote2epg.xml
+++ b/gracenote2epg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="5">
+<settings version="6">
   <!-- Basic guide settings -->
   <setting id="days">7</setting>                               <!-- Guide duration (1-14 days) -->
   <setting id="zipcode">92101</setting>                        <!-- US ZIP or Canadian postal code -->
@@ -38,4 +38,14 @@
   <setting id="logrotate">true</setting>                       <!-- Log rotation: true(daily)|false|daily|weekly|monthly -->
   <setting id="relogs">30</setting>                            <!-- Log retention: days(number) or weekly|monthly|quarterly -->
   <setting id="rexmltv">7</setting>                            <!-- XMLTV backup retention: days(number) or weekly|monthly|quarterly -->
+
+  <!-- Image source host: the first 'enabled' source is used for program/cast   -->
+  <!-- images. Mirrors serve the same images; switch by toggling status         -->
+  <!-- (enabled|disabled). www.tvtv.ca is rate-limited.                         -->
+  <imagesources>
+    <source status="enabled">https://tmsimg.fancybits.co/assets</source>
+    <source status="disabled">https://www.tvtv.ca/gn/pi/assets</source>
+    <source status="disabled">https://zap2it.tmsimg.com/assets</source>
+    <source status="disabled">https://dshm.tmsimg.com/assets</source>
+  </imagesources>
 </settings>

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev1"
+__version__ = "2.0.0-dev2"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/config/base.py
+++ b/gracenote2epg/config/base.py
@@ -83,7 +83,15 @@ class ConfigManager:
         # Set defaults for missing settings
         self._set_defaults_and_update_file()
 
+        # Parse image source hosts (after any config rewrite)
+        self.image_sources = self.settings_manager.parse_image_sources(self.config_file)
+
         return self.settings
+
+    def get_image_source(self) -> str:
+        """Active image host base URL (first enabled <imagesources> source)."""
+        sources = getattr(self, "image_sources", [])
+        return self.settings_manager.active_image_source(sources)
 
     def _parse_and_migrate_config(self):
         """Parse configuration file and handle migration if needed"""
@@ -100,13 +108,19 @@ class ConfigManager:
         migration_needed, deprecated_settings, unknown_settings, ordering_needed = \
             self.migrator.analyze_migration_needs(all_settings, valid_settings, original_order)
 
+        # A schema-version bump also needs a rewrite (e.g. to inject the
+        # <imagesources> block introduced in version 6).
+        version_upgrade_needed = self.version != self.settings_manager.CONFIG_VERSION
+
         # Process valid settings
         self._process_valid_settings(valid_settings)
 
         # Perform migration if needed
-        if migration_needed or ordering_needed:
+        if migration_needed or ordering_needed or version_upgrade_needed:
             removed_settings = deprecated_settings + unknown_settings
-            self._perform_migration(valid_settings, removed_settings, ordering_needed)
+            self._perform_migration(
+                valid_settings, removed_settings, ordering_needed, version_upgrade_needed
+            )
 
     def _process_valid_settings(self, valid_settings: Dict[str, Any]):
         """Process and type-convert valid settings"""
@@ -120,18 +134,21 @@ class ConfigManager:
                 type(processed_value).__name__,
             )
 
-    def _perform_migration(self, valid_settings: Dict[str, Any], removed_settings: List[str], ordering_needed: bool):
+    def _perform_migration(self, valid_settings: Dict[str, Any], removed_settings: List[str],
+                           ordering_needed: bool, version_upgrade: bool = False):
         """Perform configuration migration"""
         reason = []
         if removed_settings:
             reason.append(f"removed {len(removed_settings)} deprecated/unknown settings")
         if ordering_needed:
             reason.append("reordered settings for consistency")
+        if version_upgrade:
+            reason.append(f"upgraded schema to version {self.settings_manager.CONFIG_VERSION}")
 
         logging.info("Configuration update needed: %s", ", ".join(reason))
-        
+
         success = self.migrator.perform_migration(
-            self.config_file, valid_settings, removed_settings, ordering_needed
+            self.config_file, valid_settings, removed_settings, ordering_needed, version_upgrade
         )
         
         if success:

--- a/gracenote2epg/config/migration.py
+++ b/gracenote2epg/config/migration.py
@@ -96,21 +96,22 @@ class ConfigMigrator:
             logging.error("Failed to create backup: %s", str(e))
             raise
 
-    def perform_migration(self, 
+    def perform_migration(self,
                          config_file: Path,
                          valid_settings: Dict[str, Any],
                          removed_settings: List[str],
-                         ordering_needed: bool = False) -> bool:
+                         ordering_needed: bool = False,
+                         version_upgrade: bool = False) -> bool:
         """
         Perform configuration migration with backup
-        
+
         Returns:
             bool: True if migration was successful
         """
         try:
             # Create backup only if we're making changes
             backup_file = None
-            if removed_settings or ordering_needed:
+            if removed_settings or ordering_needed or version_upgrade:
                 backup_file = self.create_backup(config_file)
 
             # Write cleaned and ordered configuration
@@ -130,7 +131,8 @@ class ConfigMigrator:
             if removed_settings:
                 logging.info("  Removed settings: %s", ", ".join(removed_settings))
 
-            logging.info("  Updated to version 5 with unified retention policies")
+            from .settings import SettingsManager
+            logging.info("  Updated to configuration version %s", SettingsManager.CONFIG_VERSION)
 
             # User notification about cleanup/migration - simplified
             if removed_settings:
@@ -213,8 +215,9 @@ class ConfigMigrator:
         """Notify user about configuration upgrade with visible warning"""
         backup_file = self._backup_file_created
 
+        from .settings import SettingsManager
         logging.warning("=" * 60)
-        logging.warning("CONFIGURATION UPGRADED TO VERSION 5")
+        logging.warning("CONFIGURATION UPGRADED TO VERSION %s", SettingsManager.CONFIG_VERSION)
         if backup_file:
             logging.warning("Backup created: %s", backup_file)
         logging.warning("Updated settings: (configuration file)")
@@ -242,8 +245,11 @@ class ConfigMigrator:
                 logging.error("Migration validation failed: root element is not 'settings'")
                 return False
                 
-            if root.attrib.get("version") != "5":
-                logging.warning("Migration validation: version is not '5'")
+            from .settings import SettingsManager
+            if root.attrib.get("version") != SettingsManager.CONFIG_VERSION:
+                logging.warning(
+                    "Migration validation: version is not '%s'", SettingsManager.CONFIG_VERSION
+                )
                 
             # Count settings
             settings_count = len(root.findall("setting"))

--- a/gracenote2epg/config/settings.py
+++ b/gracenote2epg/config/settings.py
@@ -14,9 +14,13 @@ from typing import Dict, Any, List, Optional
 class SettingsManager:
     """Handles XML settings parsing and management"""
 
+    # Current config schema version. Bumped to 6 when the <imagesources> block
+    # was introduced; older files are upgraded automatically on load.
+    CONFIG_VERSION = "6"
+
     # Default configuration template
     DEFAULT_CONFIG = """<?xml version="1.0" encoding="utf-8"?>
-<settings version="5">
+<settings version="6">
   <!-- Basic guide settings -->
   <setting id="zipcode">92101</setting>
   <setting id="lineupid">auto</setting>
@@ -50,7 +54,26 @@ class SettingsManager:
   <setting id="logrotate">true</setting>
   <setting id="relogs">30</setting>
   <setting id="rexmltv">7</setting>
+
+  <!-- Image source host (first 'enabled' is used; mirrors serve the same images) -->
+  <imagesources>
+    <source status="enabled">https://tmsimg.fancybits.co/assets</source>
+    <source status="disabled">https://www.tvtv.ca/gn/pi/assets</source>
+    <source status="disabled">https://zap2it.tmsimg.com/assets</source>
+    <source status="disabled">https://dshm.tmsimg.com/assets</source>
+  </imagesources>
 </settings>"""
+
+    # Known image hosts (base URLs serving the same TMS asset codes). The first
+    # 'enabled' source is used; tvtv.ca is rate-limited so the default enables
+    # the fancybits mirror. Used when the config has no <imagesources> block.
+    DEFAULT_IMAGE_SOURCES = [
+        ("https://tmsimg.fancybits.co/assets", True),
+        ("https://www.tvtv.ca/gn/pi/assets", False),
+        ("https://zap2it.tmsimg.com/assets", False),
+        ("https://dshm.tmsimg.com/assets", False),
+    ]
+    _DISABLED_STATUSES = {"disabled", "off", "false", "0", "no"}
 
     # Settings order for clean output
     SETTINGS_ORDER = [
@@ -171,11 +194,61 @@ class SettingsManager:
 
         return False
 
+    def parse_image_sources(self, config_file: Path) -> List[tuple]:
+        """Parse the <imagesources> block; returns a list of (url, enabled).
+
+        Returns [] when the file has no block (callers fall back to the
+        default sources).
+        """
+        try:
+            root = ET.parse(config_file).getroot()
+        except Exception:
+            return []
+        block = root.find("imagesources")
+        if block is None:
+            return []
+        sources = []
+        for src in block.findall("source"):
+            url = (src.text or "").strip()
+            if not url:
+                continue
+            status = (src.get("status") or "enabled").strip().lower()
+            sources.append((url, status not in self._DISABLED_STATUSES))
+        return sources
+
+    @classmethod
+    def active_image_source(cls, sources: List[tuple]) -> str:
+        """Return the first enabled source URL, falling back to the default."""
+        for url, enabled in sources:
+            if enabled:
+                return url
+        for url, enabled in cls.DEFAULT_IMAGE_SOURCES:
+            if enabled:
+                return url
+        return cls.DEFAULT_IMAGE_SOURCES[0][0]
+
+    def _render_image_sources(self, sources: List[tuple]) -> str:
+        """Serialize the <imagesources> block (uses defaults when empty)."""
+        if not sources:
+            sources = self.DEFAULT_IMAGE_SOURCES
+        out = [
+            "\n  <!-- Image source host (first 'enabled' is used;"
+            " mirrors serve the same images) -->\n",
+            "  <imagesources>\n",
+        ]
+        for url, enabled in sources:
+            status = "enabled" if enabled else "disabled"
+            out.append(f'    <source status="{status}">{url}</source>\n')
+        out.append("  </imagesources>\n")
+        return "".join(out)
+
     def write_clean_config(self, config_file: Path, valid_settings: Dict[str, str]):
         """Write configuration file in proper order with nice formatting"""
+        # Preserve any existing <imagesources> block (read before truncating).
+        image_sources = self.parse_image_sources(config_file)
         with open(config_file, "w", encoding="utf-8") as f:
             f.write('<?xml version="1.0" encoding="utf-8"?>\n')
-            f.write('<settings version="5">\n')
+            f.write(f'<settings version="{self.CONFIG_VERSION}">\n')
 
             # Group settings with comments for better readability
             sections = [
@@ -224,6 +297,9 @@ class SettingsManager:
                         f.write(f'  <setting id="{setting_id}">{value}</setting>\n')
                     else:
                         f.write(f'  <setting id="{setting_id}"></setting>\n')
+
+            # Preserve / inject the image source block
+            f.write(self._render_image_sources(image_sources))
 
             f.write("</settings>\n")
 

--- a/gracenote2epg/main.py
+++ b/gracenote2epg/main.py
@@ -360,7 +360,9 @@ def main():
                     )
 
             # Generate XMLTV
-            xmltv_generator = XmltvGenerator(cache_manager)
+            xmltv_generator = XmltvGenerator(
+                cache_manager, image_base_url=config_manager.get_image_source()
+            )
             xmltv_success = xmltv_generator.generate_xmltv(
                 schedule=data_parser.get_schedule(), config=config, xmltv_file=xmltv_file
             )

--- a/gracenote2epg/xmltv/generator.py
+++ b/gracenote2epg/xmltv/generator.py
@@ -31,12 +31,18 @@ class XmltvGenerator(
 ):
     """Generates XMLTV files from parsed guide data - DTD Compliant"""
 
-    ASSETS_BASE_URL = "https://www.tvtv.ca/gn/pi/assets"
+    # Default image host (overridable per-instance from the config's
+    # <imagesources> block). tvtv.ca is rate-limited, so the default is a mirror.
+    ASSETS_BASE_URL = "https://tmsimg.fancybits.co/assets"
 
-    def __init__(self, cache_manager: CacheManager):
+    def __init__(self, cache_manager: CacheManager, image_base_url: Optional[str] = None):
         self.cache_manager = cache_manager
         self.station_count = 0
         self.episode_count = 0
+
+        # Image host: configured source wins, else the class default
+        if image_base_url:
+            self.ASSETS_BASE_URL = image_base_url.rstrip("/")
 
         # Language detection is handled by LanguageDetector module
         self.language_detector: Optional[LanguageDetector] = None

--- a/tests/fixtures/config_v5.xml
+++ b/tests/fixtures/config_v5.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<settings version="5">
+  <!-- Legacy version-5 config (no <imagesources> block) used to test the
+       automatic upgrade to version 6. -->
+  <setting id="zipcode">J3B1M4</setting>
+  <setting id="lineupid">auto</setting>
+  <setting id="days">1</setting>
+  <setting id="xdetails">true</setting>
+  <setting id="xdesc">true</setting>
+  <setting id="langdetect">false</setting>
+  <setting id="tvhoff">false</setting>
+  <setting id="redays">1</setting>
+  <setting id="refresh">48</setting>
+</settings>

--- a/tests/fixtures/xmltv_golden.xml
+++ b/tests/fixtures/xmltv_golden.xml
@@ -23,7 +23,7 @@
 		<category lang="en">Drama</category>
 		<language>English</language>
 		<length units="minutes">120</length>
-		<icon src="https://www.tvtv.ca/gn/pi/assets/p0000001_v_v1.jpg" />
+		<icon src="https://tmsimg.fancybits.co/assets/p0000001_v_v1.jpg" />
 		<country>CA</country>
 		<episode-num system="dd_progid">MV00000001.0000</episode-num>
 		<video>
@@ -44,9 +44,9 @@
 		<star-rating>
 			<value>3/4</value>
 		</star-rating>
-		<image type="poster" orient="P">https://www.tvtv.ca/gn/pi/assets/p0000001_v_h9_poster.jpg</image>
-		<image type="backdrop" orient="L">https://www.tvtv.ca/gn/pi/assets/p0000001_k_h9_backdrop.jpg</image>
-		<image type="still" orient="L">https://www.tvtv.ca/gn/pi/assets/p0000001_v_v1.jpg</image>
+		<image type="poster" orient="P">https://tmsimg.fancybits.co/assets/p0000001_v_h9_poster.jpg</image>
+		<image type="backdrop" orient="L">https://tmsimg.fancybits.co/assets/p0000001_k_h9_backdrop.jpg</image>
+		<image type="still" orient="L">https://tmsimg.fancybits.co/assets/p0000001_v_v1.jpg</image>
 	</programme>
 	<programme start="20270115100000 +0000" stop="20270115103000 +0000" channel="12345.gracenote2epg">
 		<title lang="en">Example Series</title>
@@ -56,7 +56,7 @@
 		<category lang="en">Sitcom</category>
 		<language>English</language>
 		<length units="minutes">30</length>
-		<icon src="https://www.tvtv.ca/gn/pi/assets/p0000002_b_v1.jpg" />
+		<icon src="https://tmsimg.fancybits.co/assets/p0000002_b_v1.jpg" />
 		<country>CA</country>
 		<episode-num system="dd_progid">EP00000002.0001</episode-num>
 		<episode-num system="onscreen">S01E01</episode-num>
@@ -72,8 +72,8 @@
 		</audio>
 		<new />
 		<subtitles type="teletext" />
-		<image type="poster" orient="P">https://www.tvtv.ca/gn/pi/assets/p0000002_b_v1.jpg</image>
-		<image type="backdrop" orient="L">https://www.tvtv.ca/gn/pi/assets/p0000002_i_h9_backdrop.jpg</image>
-		<image type="still" orient="L">https://www.tvtv.ca/gn/pi/assets/p0000002_still.jpg</image>
+		<image type="poster" orient="P">https://tmsimg.fancybits.co/assets/p0000002_b_v1.jpg</image>
+		<image type="backdrop" orient="L">https://tmsimg.fancybits.co/assets/p0000002_i_h9_backdrop.jpg</image>
+		<image type="still" orient="L">https://tmsimg.fancybits.co/assets/p0000002_still.jpg</image>
 	</programme>
 </tv>

--- a/tests/test_image_source.py
+++ b/tests/test_image_source.py
@@ -1,0 +1,89 @@
+"""Tests for the configurable <imagesources> image host block."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from gracenote2epg.config.settings import SettingsManager
+from gracenote2epg.cache import CacheManager
+from gracenote2epg.xmltv import XmltvGenerator
+
+FANCYBITS = "https://tmsimg.fancybits.co/assets"
+TVTV = "https://www.tvtv.ca/gn/pi/assets"
+
+
+def _write(xml):
+    p = Path(tempfile.mkdtemp()) / "config.xml"
+    p.write_text('<?xml version="1.0"?>\n' + xml)
+    return p
+
+
+class ParseTests(unittest.TestCase):
+    def setUp(self):
+        self.sm = SettingsManager()
+
+    def test_parses_sources_with_status(self):
+        p = _write(
+            "<settings><imagesources>"
+            f'<source status="disabled">{TVTV}</source>'
+            f'<source status="enabled">{FANCYBITS}</source>'
+            "</imagesources></settings>"
+        )
+        self.assertEqual(self.sm.parse_image_sources(p), [(TVTV, False), (FANCYBITS, True)])
+
+    def test_no_block_returns_empty(self):
+        p = _write('<settings><setting id="days">7</setting></settings>')
+        self.assertEqual(self.sm.parse_image_sources(p), [])
+
+    def test_missing_status_defaults_enabled(self):
+        p = _write(f"<settings><imagesources><source>{FANCYBITS}</source></imagesources></settings>")
+        self.assertEqual(self.sm.parse_image_sources(p), [(FANCYBITS, True)])
+
+
+class ActiveSourceTests(unittest.TestCase):
+    def test_first_enabled_wins(self):
+        self.assertEqual(
+            SettingsManager.active_image_source([(TVTV, False), (FANCYBITS, True)]), FANCYBITS
+        )
+
+    def test_empty_falls_back_to_default(self):
+        self.assertEqual(SettingsManager.active_image_source([]), FANCYBITS)
+
+    def test_none_enabled_falls_back_to_default(self):
+        self.assertEqual(SettingsManager.active_image_source([(TVTV, False)]), FANCYBITS)
+
+
+class RoundTripTests(unittest.TestCase):
+    def setUp(self):
+        self.sm = SettingsManager()
+
+    def test_block_preserved_on_rewrite(self):
+        p = _write(
+            "<settings version=\"5\">"
+            f'<imagesources><source status="enabled">{TVTV}</source></imagesources>'
+            "</settings>"
+        )
+        before = self.sm.parse_image_sources(p)
+        self.sm.write_clean_config(p, {"days": "7"})
+        self.assertEqual(self.sm.parse_image_sources(p), before)
+
+    def test_default_block_injected_when_absent(self):
+        p = _write('<settings version="5"><setting id="days">7</setting></settings>')
+        self.sm.write_clean_config(p, {"days": "7"})
+        self.assertEqual(self.sm.active_image_source(self.sm.parse_image_sources(p)), FANCYBITS)
+
+
+class GeneratorTests(unittest.TestCase):
+    def _gen(self, url=None):
+        cm = CacheManager(Path(tempfile.mkdtemp()) / "cache")
+        return XmltvGenerator(cm, image_base_url=url)
+
+    def test_default_host_is_a_mirror_not_tvtv(self):
+        self.assertEqual(self._gen().ASSETS_BASE_URL, FANCYBITS)
+
+    def test_configured_url_overrides_default(self):
+        self.assertEqual(self._gen(TVTV + "/").ASSETS_BASE_URL, TVTV)  # trailing slash stripped
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,49 @@
+"""Config schema migration: a version-5 file upgrades to 6 + gets the block."""
+
+import shutil
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from gracenote2epg.config.base import ConfigManager
+from gracenote2epg.config.settings import SettingsManager
+
+FIXTURE_V5 = Path(__file__).parent / "fixtures" / "config_v5.xml"
+
+
+class MigrationV5toV6Tests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.cfg = self.tmp / "gracenote2epg.xml"
+        shutil.copy(FIXTURE_V5, self.cfg)
+
+    def _root(self):
+        return ET.parse(self.cfg).getroot()
+
+    def test_fixture_starts_at_v5_without_block(self):
+        root = self._root()
+        self.assertEqual(root.attrib.get("version"), "5")
+        self.assertIsNone(root.find("imagesources"))
+
+    def test_load_upgrades_to_v6_and_injects_block(self):
+        ConfigManager(self.cfg).load_config()
+        root = self._root()
+        self.assertEqual(root.attrib.get("version"), SettingsManager.CONFIG_VERSION)  # "6"
+        block = root.find("imagesources")
+        self.assertIsNotNone(block, "migration should inject the <imagesources> block")
+        self.assertGreaterEqual(len(block.findall("source")), 1)
+
+    def test_upgraded_config_resolves_default_image_source(self):
+        cm = ConfigManager(self.cfg)
+        cm.load_config()
+        self.assertEqual(cm.get_image_source(), "https://tmsimg.fancybits.co/assets")
+
+    def test_version_upgrade_creates_a_backup(self):
+        ConfigManager(self.cfg).load_config()
+        backups = list(self.tmp.glob("gracenote2epg.xml.backup.*"))
+        self.assertTrue(backups, "a one-time schema upgrade should back up the old config")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Makes the **image host configurable** via a new `<imagesources>` config block,
and bumps the config schema to **version 6** (with automatic upgrade of older
configs). `www.tvtv.ca` rate-limits image serving; the Gracenote/TMS asset codes
are served identically by mirror hosts, so only the base URL needs to change.

## Changes

### `<imagesources>` config block
```xml
<imagesources>
  <source status="enabled">https://tmsimg.fancybits.co/assets</source>
  <source status="disabled">https://www.tvtv.ca/gn/pi/assets</source>
  <source status="disabled">https://zap2it.tmsimg.com/assets</source>
  <source status="disabled">https://dshm.tmsimg.com/assets</source>
</imagesources>
```
- The **first `enabled` source is used**; switch host by toggling `status`
  (no need to retype URLs). You can add your own full base URL too.
- Default host is the `fancybits` mirror (tvtv.ca is rate-limited).
- `XmltvGenerator.ASSETS_BASE_URL` is now set from the config and used by both
  `<icon>` and the typed `<image>` elements. Affects only the image URLs written
  to the guide — never which channels/programmes are downloaded.

### Schema version 6 + auto-migration
- Bumped to schema version 6 (single source of truth `SettingsManager.CONFIG_VERSION`).
- Version-5 configs are upgraded automatically on load: the block is injected
  with defaults and a backup is written (a schema upgrade now triggers a backup,
  unlike a no-op run). `write_clean_config` preserves an existing block.

## Tests & docs
- New `tests/test_image_source.py` (parsing, selection, write round-trip) and
  `tests/test_migration.py` with `tests/fixtures/config_v5.xml` (v5 → v6 upgrade).
  `tests/baseline/` stays at version 5 (git-ignored) for manual migration checks.
- Docs updated: configuration (Image Source section + v6 note), changelog,
  tvheadend, lineup. 65 tests pass; golden regenerated, DTD-valid.
- Version bumped to `2.0.0-dev2`.
