### PR TITLE
Validation & corrections: black/flake8 clean + SonarCloud code-smell pass

### DIFF
--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev2"
+__version__ = "2.0.0-dev3"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/args/__init__.py
+++ b/gracenote2epg/args/__init__.py
@@ -13,9 +13,9 @@ from .systems import SystemDetector
 
 # Primary export
 __all__ = [
-    "ArgumentParser",      # Main public interface
-    "ArgumentValidator",   # For testing/validation
-    "LocationProcessor",   # For location handling
-    "PathManager",         # For path management
-    "SystemDetector",      # For system detection
+    "ArgumentParser",  # Main public interface
+    "ArgumentValidator",  # For testing/validation
+    "LocationProcessor",  # For location handling
+    "PathManager",  # For path management
+    "SystemDetector",  # For system detection
 ]

--- a/gracenote2epg/args/base.py
+++ b/gracenote2epg/args/base.py
@@ -6,7 +6,6 @@ Provides baseline XMLTV grabber capabilities and lineup testing functionality.
 """
 
 import argparse
-import logging
 import sys
 from pathlib import Path
 
@@ -17,57 +16,50 @@ from .path_manager import PathManager
 
 class ArgumentParser:
     """Command line argument parser for gracenote2epg"""
-    
+
     def __init__(self):
         self.parser = self._create_parser()
         self.validator = ArgumentValidator()
         self.location_processor = LocationProcessor()
         self.path_manager = PathManager()
-    
+
     def _create_parser(self):
         """Create the argument parser with all options"""
         parser = argparse.ArgumentParser(
             prog="gracenote2epg",
             description="North America TV guide grabber (gracenote.com)",
             formatter_class=argparse.RawDescriptionHelpFormatter,
-            epilog=self._get_epilog_text()
+            epilog=self._get_epilog_text(),
         )
-        
+
         # XMLTV baseline capabilities
         parser.add_argument(
-            "--description", "-d", action="store_true", 
-            help="Show grabber description and exit"
+            "--description", "-d", action="store_true", help="Show grabber description and exit"
         )
-        
+
+        parser.add_argument("--version", "-v", action="store_true", help="Show version and exit")
+
         parser.add_argument(
-            "--version", "-v", action="store_true", 
-            help="Show version and exit"
+            "--capabilities", "-c", action="store_true", help="Show capabilities and exit"
         )
-        
-        parser.add_argument(
-            "--capabilities", "-c", action="store_true", 
-            help="Show capabilities and exit"
-        )
-        
+
         # LineupID detection and testing
         parser.add_argument(
             "--show-lineup",
             action="store_true",
             help="Show auto-detected lineupID for configured postal/ZIP code and exit (testing mode)",
         )
-        
+
         # Log level selection
         level_group = parser.add_mutually_exclusive_group()
         level_group.add_argument(
-            "--warning", "-w", action="store_true", 
-            help="Only warnings and errors to file"
+            "--warning", "-w", action="store_true", help="Only warnings and errors to file"
         )
-        
+
         level_group.add_argument(
-            "--debug", action="store_true", 
-            help="All debug information to file (very verbose)"
+            "--debug", action="store_true", help="All debug information to file (very verbose)"
         )
-        
+
         # Console output control
         console_group = parser.add_mutually_exclusive_group()
         console_group.add_argument(
@@ -75,30 +67,24 @@ class ArgumentParser:
             action="store_true",
             help="Display active log level to console (can combine with --warning/--debug)",
         )
-        
+
         console_group.add_argument(
-            "--quiet", "-q",
+            "--quiet",
+            "-q",
             action="store_true",
             help="No console output except XML, logs to file only",
         )
-        
+
         # Output control
         parser.add_argument(
-            "--output", "-o", type=Path, 
-            help="Redirect XMLTV output to specified file"
+            "--output", "-o", type=Path, help="Redirect XMLTV output to specified file"
         )
-        
+
         # Guide parameters
-        parser.add_argument(
-            "--days", type=int, 
-            help="Number of days to download (1-14)"
-        )
-        
-        parser.add_argument(
-            "--offset", type=int, 
-            help="Start with data for day today plus X days"
-        )
-        
+        parser.add_argument("--days", type=int, help="Number of days to download (1-14)")
+
+        parser.add_argument("--offset", type=int, help="Start with data for day today plus X days")
+
         # Cache refresh control
         refresh_group = parser.add_mutually_exclusive_group()
         refresh_group.add_argument(
@@ -106,14 +92,14 @@ class ArgumentParser:
             action="store_true",
             help="Don't refresh cached blocks (use all cached data, fastest)",
         )
-        
+
         refresh_group.add_argument(
             "--refresh",
             type=int,
             metavar="HOURS",
             help="Refresh blocks from the first HOURS hours (default: 48, range: 0-168)",
         )
-        
+
         # Language detection
         parser.add_argument(
             "--langdetect",
@@ -121,44 +107,31 @@ class ArgumentParser:
             choices=["true", "false"],
             help="Enable/disable automatic language detection (requires langdetect library)",
         )
-        
+
         # Lineup configuration
         parser.add_argument(
             "--lineupid",
             type=str,
             help="Override lineup configuration (auto, CAN-OTAJ3B1M4, CAN-0005993-X, etc.)",
         )
-        
+
         # Location codes
         location_group = parser.add_mutually_exclusive_group()
-        location_group.add_argument(
-            "--zip", type=str, 
-            help="US ZIP code (5 digits)"
-        )
-        
-        location_group.add_argument(
-            "--postal", type=str, 
-            help="Canadian postal code (A1A 1A1)"
-        )
-        
-        location_group.add_argument(
-            "--code", type=str, 
-            help="US ZIP or Canadian postal code"
-        )
-        
+        location_group.add_argument("--zip", type=str, help="US ZIP code (5 digits)")
+
+        location_group.add_argument("--postal", type=str, help="Canadian postal code (A1A 1A1)")
+
+        location_group.add_argument("--code", type=str, help="US ZIP or Canadian postal code")
+
         # Configuration
+        parser.add_argument("--config-file", type=Path, help="Configuration file path")
+
         parser.add_argument(
-            "--config-file", type=Path, 
-            help="Configuration file path"
+            "--basedir", type=Path, help="Base directory for config, cache, and logs"
         )
-        
-        parser.add_argument(
-            "--basedir", type=Path, 
-            help="Base directory for config, cache, and logs"
-        )
-        
+
         return parser
-    
+
     def _get_epilog_text(self):
         """Get the epilog help text"""
         return """
@@ -224,125 +197,127 @@ LineupID Auto-Detection:
   - Canada: CAN-OTAJ3B1M4-DEFAULT (from postal code J3B1M4)
   - USA:    USA-OTA90210-DEFAULT   (from ZIP code 90210)
         """
-    
+
     def parse_args(self, args=None):
         """Parse command line arguments with validation"""
         args = self.parser.parse_args(args)
-        
+
         # Handle special actions that exit immediately
         if self._handle_special_actions(args):
             sys.exit(0)
-        
+
         # Handle --show-lineup
         if self._handle_show_lineup(args):
             sys.exit(0)
-        
+
         # Validate arguments
         self._validate_args(args)
-        
+
         # Process lineup and location
         self._process_lineup_and_location(args)
-        
+
         # Normalize options
         self._normalize_options(args)
-        
+
         return args
-    
+
     def _handle_special_actions(self, args) -> bool:
         """Handle special actions that exit immediately"""
         if args.description:
             print("North America (tvlistings.gracenote.com using gracenote2epg)")
             return True
-            
+
         if args.version:
             from .. import __version__
+
             print(__version__)
             return True
-            
+
         if args.capabilities:
             print("baseline")
             return True
-            
+
         return False
-    
+
     def _handle_show_lineup(self, args) -> bool:
         """Handle --show-lineup option"""
         if not args.show_lineup:
             return False
-            
+
         location_code = args.zip or args.postal or args.code
         if not location_code:
             self.parser.error("--show-lineup requires one of: --zip, --postal, or --code")
-        
+
         # Delegated to ConfigManager for the lineup logic
         from ..config import ConfigManager
+
         temp_config = ConfigManager(Path("temp"))
         debug_mode = args.debug if hasattr(args, "debug") else False
-        
+
         if not temp_config.display_lineup_detection_test(location_code, debug_mode):
             sys.exit(1)
-            
+
         return True
-    
+
     def _validate_args(self, args):
         """Validate argument values"""
         errors = []
-        
+
         # Validate days
         valid, error = self.validator.validate_days(args.days)
         if not valid:
             errors.append(error)
-        
+
         # Validate offset
         valid, error = self.validator.validate_offset(args.offset)
         if not valid:
             errors.append(error)
-        
+
         # Validate refresh
         valid, error = self.validator.validate_refresh(args.refresh)
         if not valid:
             errors.append(error)
-        
+
         # Validate lineupid
         valid, error = self.validator.validate_lineupid(args.lineupid)
         if not valid:
             errors.append(error)
-        
+
         # If any errors, report them
         if errors:
             for error in errors:
                 self.parser.error(error)
-    
+
     def _process_lineup_and_location(self, args):
         """Process lineup and location arguments"""
         try:
             location_code, metadata = self.location_processor.process_lineup_and_location(args)
-            
+
             # Store results in args
             args.location_code = location_code
-            args.location_source = metadata['location_source']
-            args.original_lineupid = metadata['original_lineupid']
-            args.extracted_location = metadata['extracted_location']
-            
+            args.location_source = metadata["location_source"]
+            args.original_lineupid = metadata["original_lineupid"]
+            args.extracted_location = metadata["extracted_location"]
+
             # Clean up individual fields
             del args.zip, args.postal, args.code
-            
+
         except ValueError as e:
             self.parser.error(str(e))
-    
+
     def _normalize_options(self, args):
         """Normalize various options"""
         # Normalize langdetect
         args.langdetect = self.location_processor.normalize_langdetect(args.langdetect)
-        
+
         # Normalize refresh
         args.refresh_hours = self.location_processor.normalize_refresh(args)
-        
+
         # Clean up individual refresh fields
         del args.norefresh
-        if hasattr(args, 'refresh'):
+        if hasattr(args, "refresh"):
             del args.refresh
-    
+
     def get_logging_config(self, args):
         """Determine logging configuration from arguments"""
         config = {
@@ -350,19 +325,19 @@ LineupID Auto-Detection:
             "console": False,
             "quiet": False,
         }
-        
+
         if args.debug:
             config["level"] = "debug"
         elif args.warning:
             config["level"] = "warning"
-        
+
         if args.console:
             config["console"] = True
         elif args.quiet:
             config["quiet"] = True
-            
+
         return config
-    
+
     def get_system_defaults(self, base_dir=None):
         """Get default directories, rooted at base_dir (--basedir) when given"""
         return self.path_manager.get_system_defaults(base_dir)

--- a/gracenote2epg/args/location.py
+++ b/gracenote2epg/args/location.py
@@ -14,30 +14,30 @@ from .validator import ArgumentValidator
 
 class LocationProcessor:
     """Processes and validates location codes"""
-    
+
     @staticmethod
     def extract_location_from_lineup(lineupid: str) -> Optional[str]:
         """
         Extract postal/ZIP code from lineup ID if it's in OTA format
-        
+
         Args:
             lineupid: Lineup ID (e.g., 'CAN-OTAJ3B1M4', 'USA-OTA90210')
-            
+
         Returns:
             Extracted location code or None if not extractable
         """
         if not lineupid:
             return None
-            
+
         # Pattern for OTA lineups: COUNTRY-OTA<LOCATION>[-DEFAULT]
         # Examples: CAN-OTAJ3B1M4, USA-OTA90210, CAN-OTAJ3B1M4-DEFAULT
         ota_pattern = re.compile(r"^(CAN|USA)-OTA([A-Z0-9]+)(?:-DEFAULT)?$", re.IGNORECASE)
-        
+
         match = ota_pattern.match(lineupid.strip())
         if match:
             country = match.group(1).upper()
             location = match.group(2).upper()
-            
+
             # Validate extracted location format
             if country == "CAN":
                 # Canadian postal: should be A1A1A1 format
@@ -48,40 +48,46 @@ class LocationProcessor:
                 # US ZIP: should be 5 digits
                 if re.match(r"^[0-9]{5}$", location):
                     return location
-                    
+
         return None
-    
+
     @staticmethod
     def process_lineup_and_location(args) -> Tuple[Optional[str], dict]:
         """
         Process lineup and location arguments with intelligent extraction and validation
-        
+
         Args:
             args: Parsed arguments object
-            
+
         Returns:
             Tuple of (final_location_code, metadata_dict)
         """
-        location_code = getattr(args, 'zip', None) or getattr(args, 'postal', None) or getattr(args, 'code', None)
-        lineupid = getattr(args, 'lineupid', None)
-        
+        location_code = (
+            getattr(args, "zip", None)
+            or getattr(args, "postal", None)
+            or getattr(args, "code", None)
+        )
+        lineupid = getattr(args, "lineupid", None)
+
         # Extract postal/ZIP from lineupid if it's an OTA format
         extracted_location = None
         if lineupid:
             extracted_location = LocationProcessor.extract_location_from_lineup(lineupid)
-        
+
         metadata = {
-            'location_source': None,
-            'original_lineupid': lineupid,
-            'extracted_location': extracted_location.replace(" ", "") if extracted_location else None
+            "location_source": None,
+            "original_lineupid": lineupid,
+            "extracted_location": (
+                extracted_location.replace(" ", "") if extracted_location else None
+            ),
         }
-        
+
         # Case 1: Both lineupid (with location) and explicit location provided
         if extracted_location and location_code:
             # Verify consistency
             clean_extracted = extracted_location.replace(" ", "").upper()
             clean_provided = location_code.replace(" ", "").upper()
-            
+
             if clean_extracted != clean_provided:
                 # Normalize display for error message
                 normalized_extracted = extracted_location.replace(" ", "")
@@ -89,68 +95,76 @@ class LocationProcessor:
                     f"Inconsistent location codes: lineupid contains '{normalized_extracted}' "
                     f"but explicit location is '{location_code}'. They must match."
                 )
-            
+
             # Use the explicitly provided format (might have spaces)
             final_location = location_code
-            metadata['location_source'] = "explicit"
-            
+            metadata["location_source"] = "explicit"
+
         # Case 2: Only lineupid provided with extractable location
         elif extracted_location and not location_code:
             final_location = extracted_location
-            metadata['location_source'] = "extracted"
+            metadata["location_source"] = "extracted"
             logging.debug(f"Extracted location '{extracted_location}' from lineupid '{lineupid}'")
-            
+
         # Case 3: Only explicit location provided
         elif location_code:
             final_location = location_code
-            metadata['location_source'] = "explicit"
-            
+            metadata["location_source"] = "explicit"
+
         # Case 4: Neither provided
         else:
             final_location = None
-        
+
         # Validate the final location code if we have one
         if final_location:
             valid, error_msg = ArgumentValidator.validate_location_code(final_location)
             if not valid:
-                source = "lineupid" if extracted_location and not location_code else "explicit parameter"
-                display_location = final_location.replace(" ", "") if extracted_location and not location_code else final_location
-                raise ValueError(f"Invalid location code from {source}: {display_location}. {error_msg}")
-            
+                source = (
+                    "lineupid" if extracted_location and not location_code else "explicit parameter"
+                )
+                display_location = (
+                    final_location.replace(" ", "")
+                    if extracted_location and not location_code
+                    else final_location
+                )
+                raise ValueError(
+                    f"Invalid location code from {source}: {display_location}. {error_msg}"
+                )
+
             # Store normalized version (without spaces)
             final_location = final_location.replace(" ", "")
-            
+
         return final_location, metadata
-    
+
     @staticmethod
     def normalize_langdetect(langdetect: Optional[str]) -> Optional[bool]:
         """
         Normalize langdetect option
-        
+
         Args:
             langdetect: String value 'true' or 'false'
-            
+
         Returns:
             Boolean value or None
         """
         if langdetect:
             return langdetect.lower() == "true"
         return None
-    
+
     @staticmethod
     def normalize_refresh(args) -> Optional[int]:
         """
         Normalize refresh options
-        
+
         Args:
             args: Parsed arguments object
-            
+
         Returns:
             Refresh hours or None
         """
-        if getattr(args, 'norefresh', False):
+        if getattr(args, "norefresh", False):
             return 0  # No refresh
-        elif getattr(args, 'refresh', None) is not None:
+        elif getattr(args, "refresh", None) is not None:
             return args.refresh
         else:
             return None  # Use config default

--- a/gracenote2epg/args/path_manager.py
+++ b/gracenote2epg/args/path_manager.py
@@ -13,7 +13,7 @@ from .systems import SystemDetector
 
 class PathManager:
     """Manages system-specific paths and directory creation"""
-    
+
     @staticmethod
     def get_system_defaults(base_dir: Optional[Path] = None) -> Dict[str, Path]:
         """
@@ -41,12 +41,12 @@ class PathManager:
             "xmltv_file": base_dir / "cache" / "xmltv.xml",
             "log_file": base_dir / "log" / "gracenote2epg.log",
         }
-    
+
     @staticmethod
     def create_directories(defaults: Dict[str, Path]):
         """
         Create required directories with proper 755 permissions
-        
+
         Args:
             defaults: Dictionary containing directory paths
         """

--- a/gracenote2epg/args/systems/__init__.py
+++ b/gracenote2epg/args/systems/__init__.py
@@ -11,8 +11,8 @@ from .raspberry import RaspberryDetector
 from .linux import LinuxDetector
 
 __all__ = [
-    "SystemDetector",     # Main orchestrator
-    "SynologyDetector",   # Synology NAS specific
+    "SystemDetector",  # Main orchestrator
+    "SynologyDetector",  # Synology NAS specific
     "RaspberryDetector",  # Raspberry Pi specific
-    "LinuxDetector",      # Generic Linux fallback
+    "LinuxDetector",  # Generic Linux fallback
 ]

--- a/gracenote2epg/args/systems/base.py
+++ b/gracenote2epg/args/systems/base.py
@@ -17,29 +17,29 @@ from .linux import LinuxDetector
 
 class SystemDetector:
     """Main system detection orchestrator"""
-    
+
     # Registry of system detectors in priority order
     DETECTORS = [
-        SynologyDetector,    # Check Synology first (most specific)
-        RaspberryDetector,   # Then Raspberry Pi
-        LinuxDetector,       # Fallback to generic Linux
+        SynologyDetector,  # Check Synology first (most specific)
+        RaspberryDetector,  # Then Raspberry Pi
+        LinuxDetector,  # Fallback to generic Linux
         # Future: WindowsDetector, MacOSDetector, DockerDetector
     ]
-    
+
     def __init__(self):
         self._detected_system = None
         self._detector_instance = None
-    
+
     def detect_system(self) -> str:
         """
         Detect system type using registered detectors
-        
+
         Returns:
             str: System type identifier ('synology', 'raspberry', 'linux', etc.)
         """
         if self._detected_system is not None:
             return self._detected_system
-        
+
         for detector_class in self.DETECTORS:
             detector = detector_class()
             if detector.detect():
@@ -47,55 +47,55 @@ class SystemDetector:
                 self._detector_instance = detector
                 logging.debug(f"System detected: {self._detected_system}")
                 return self._detected_system
-        
+
         # Should never happen as LinuxDetector is catch-all
-        self._detected_system = 'unknown'
+        self._detected_system = "unknown"
         return self._detected_system
-    
+
     def get_base_path(self, home: Path = None) -> Path:
         """
         Get system-specific base path for gracenote2epg
-        
+
         Args:
             home: Home directory (defaults to Path.home())
-            
+
         Returns:
             Path: Base directory for the detected system
         """
         if home is None:
             home = Path.home()
-        
+
         # Ensure detection has run
         if self._detector_instance is None:
             self.detect_system()
-        
+
         if self._detector_instance:
             return self._detector_instance.get_base_path(home)
-        
+
         # Fallback
         return home / "gracenote2epg"
-    
+
     def get_system_info(self) -> Dict:
         """
         Get detailed system information
-        
+
         Returns:
             Dict: System-specific information
         """
         # Ensure detection has run
         if self._detector_instance is None:
             self.detect_system()
-        
+
         if self._detector_instance:
             return self._detector_instance.get_system_info()
-        
+
         return {"type": "unknown", "version": None}
-    
+
     @classmethod
     def register_detector(cls, detector_class, priority: Optional[int] = None):
         """
         Register a new system detector
-        
+
         Args:
             detector_class: Detector class to register
             priority: Position in detector list (None = append to end)

--- a/gracenote2epg/args/systems/linux.py
+++ b/gracenote2epg/args/systems/linux.py
@@ -13,27 +13,27 @@ from typing import Dict
 
 class LinuxDetector:
     """Generic Linux detection and configuration"""
-    
+
     system_type = "linux"
-    
+
     def detect(self) -> bool:
         """
         Detect generic Linux system (catch-all)
-        
+
         Returns:
             bool: Always True as this is the fallback
         """
         # This is the catch-all detector, always returns True
         # More specific detectors should be checked first
         return True
-    
+
     def get_base_path(self, home: Path) -> Path:
         """
         Get Linux-specific base path
-        
+
         Args:
             home: User home directory
-            
+
         Returns:
             Path: Base directory for gracenote2epg
         """
@@ -45,7 +45,7 @@ class LinuxDetector:
                 Path("/data/gracenote2epg"),
                 Path("/app/gracenote2epg"),
             ]
-            
+
             for docker_path in docker_paths:
                 try:
                     if docker_path.parent.exists():
@@ -55,7 +55,7 @@ class LinuxDetector:
                     continue
                 except Exception:
                     continue
-        
+
         # Check for TVheadend installation
         tvheadend_paths = [
             Path("/usr/share/tvheadend/data/epggrab/gracenote2epg"),
@@ -63,7 +63,7 @@ class LinuxDetector:
             Path("/etc/tvheadend/epggrab/gracenote2epg"),
             home / ".hts" / "tvheadend" / "epggrab" / "gracenote2epg",
         ]
-        
+
         for tvh_path in tvheadend_paths:
             try:
                 if tvh_path.parent.exists():
@@ -77,23 +77,23 @@ class LinuxDetector:
                 # Skip any other errors
                 logging.debug(f"Error checking path {tvh_path.parent}: {e}")
                 continue
-        
+
         # Default Linux path in home directory
         default_path = home / "gracenote2epg"
         logging.debug(f"Using default Linux path: {default_path}")
         return default_path
-    
+
     def _is_docker(self) -> bool:
         """
         Check if running inside a Docker container
-        
+
         Returns:
             bool: True if Docker environment detected
         """
         # Method 1: Check for .dockerenv file
         if Path("/.dockerenv").exists():
             return True
-        
+
         # Method 2: Check cgroup for docker
         try:
             with open("/proc/1/cgroup", "r") as f:
@@ -101,17 +101,17 @@ class LinuxDetector:
                     return True
         except Exception:
             pass
-        
+
         # Method 3: Check environment variables
         if os.environ.get("DOCKER_CONTAINER"):
             return True
-        
+
         return False
-    
+
     def _get_distribution_info(self) -> Dict:
         """
         Get Linux distribution information
-        
+
         Returns:
             Dict: Distribution details
         """
@@ -119,7 +119,7 @@ class LinuxDetector:
             "distribution": "unknown",
             "version": None,
         }
-        
+
         # Try to read from os-release (most modern distributions)
         os_release = Path("/etc/os-release")
         if os_release.exists():
@@ -132,7 +132,7 @@ class LinuxDetector:
                             dist_info["version"] = line.split("=")[1].strip().strip('"')
             except Exception:
                 pass
-        
+
         # Fallback to older methods
         elif Path("/etc/debian_version").exists():
             dist_info["distribution"] = "debian"
@@ -141,7 +141,7 @@ class LinuxDetector:
                     dist_info["version"] = f.read().strip()
             except Exception:
                 pass
-        
+
         elif Path("/etc/redhat-release").exists():
             dist_info["distribution"] = "redhat"
             try:
@@ -149,18 +149,19 @@ class LinuxDetector:
                     content = f.read().strip()
                     # Extract version from string like "CentOS Linux release 7.9.2009"
                     import re
-                    version_match = re.search(r'release\s+([\d.]+)', content)
+
+                    version_match = re.search(r"release\s+([\d.]+)", content)
                     if version_match:
                         dist_info["version"] = version_match.group(1)
             except Exception:
                 pass
-        
+
         return dist_info
-    
+
     def get_system_info(self) -> Dict:
         """
         Get Linux system information
-        
+
         Returns:
             Dict: System details including distribution
         """
@@ -169,18 +170,19 @@ class LinuxDetector:
             "is_docker": self._is_docker(),
             "kernel_version": None,
         }
-        
+
         # Get distribution information
         dist_info = self._get_distribution_info()
         info.update(dist_info)
-        
+
         # Get kernel version
         try:
             import platform
+
             info["kernel_version"] = platform.release()
         except Exception:
             pass
-        
+
         # Check for TVheadend
         tvheadend_markers = [
             Path("/usr/bin/tvheadend"),
@@ -188,7 +190,7 @@ class LinuxDetector:
             Path("/var/lib/tvheadend"),
             Path.home() / ".hts" / "tvheadend",
         ]
-        
+
         tvheadend_detected = False
         for path in tvheadend_markers:
             try:
@@ -200,7 +202,7 @@ class LinuxDetector:
                 continue
             except Exception:
                 continue
-        
+
         info["tvheadend_detected"] = tvheadend_detected
-        
+
         return info

--- a/gracenote2epg/args/systems/raspberry.py
+++ b/gracenote2epg/args/systems/raspberry.py
@@ -11,13 +11,13 @@ from typing import Dict
 
 class RaspberryDetector:
     """Raspberry Pi detection and configuration"""
-    
+
     system_type = "raspberry"
-    
+
     def detect(self) -> bool:
         """
         Detect if running on Raspberry Pi
-        
+
         Returns:
             bool: True if Raspberry Pi detected
         """
@@ -32,7 +32,7 @@ class RaspberryDetector:
                         return True
             except Exception as e:
                 logging.debug(f"Error reading device-tree model: {e}")
-        
+
         # Method 2: Check CPU info
         cpuinfo = Path("/proc/cpuinfo")
         if cpuinfo.exists():
@@ -45,28 +45,28 @@ class RaspberryDetector:
                         return True
             except Exception as e:
                 logging.debug(f"Error reading cpuinfo: {e}")
-        
+
         # Method 3: Check for Raspberry Pi specific files
         rpi_markers = [
             "/opt/vc/bin/vcgencmd",  # VideoCore tools
-            "/boot/config.txt",      # RPi boot config
+            "/boot/config.txt",  # RPi boot config
             "/sys/firmware/devicetree/base/model",  # Alternative model location
         ]
-        
+
         for marker in rpi_markers:
             if Path(marker).exists():
                 logging.debug(f"Raspberry Pi detected via marker: {marker}")
                 return True
-        
+
         return False
-    
+
     def get_base_path(self, home: Path) -> Path:
         """
         Get Raspberry Pi specific base path
-        
+
         Args:
             home: User home directory
-            
+
         Returns:
             Path: Base directory for gracenote2epg
         """
@@ -76,27 +76,27 @@ class RaspberryDetector:
             home / ".kodi" / "addons" / "script.module.gracenote2epg",
             home / ".xbmc" / "addons" / "script.module.gracenote2epg",
         ]
-        
+
         for kodi_path in kodi_paths:
             if kodi_path.exists():
                 logging.debug(f"Using Kodi integration path: {kodi_path}")
                 return kodi_path
-        
+
         # Check for OSMC (Raspberry Pi media center)
         if Path("/home/osmc").exists() and home == Path("/home/osmc"):
             osmc_path = home / "gracenote2epg"
             logging.debug(f"OSMC detected, using: {osmc_path}")
             return osmc_path
-        
+
         # Default Raspberry Pi path
         default_path = home / "gracenote2epg"
         logging.debug(f"Using default Raspberry Pi path: {default_path}")
         return default_path
-    
+
     def get_system_info(self) -> Dict:
         """
         Get Raspberry Pi system information
-        
+
         Returns:
             Dict: System details including model
         """
@@ -107,17 +107,17 @@ class RaspberryDetector:
             "kodi_detected": False,
             "osmc_detected": False,
         }
-        
+
         # Try to get model information
         try:
             device_tree_model = Path("/proc/device-tree/model")
             if device_tree_model.exists():
                 with open(device_tree_model, "r") as f:
-                    model = f.read().strip().replace('\x00', '')
+                    model = f.read().strip().replace("\x00", "")
                     info["model"] = model
         except Exception:
             pass
-        
+
         # Try to get revision from cpuinfo
         try:
             cpuinfo = Path("/proc/cpuinfo")
@@ -130,7 +130,7 @@ class RaspberryDetector:
                             break
         except Exception:
             pass
-        
+
         # Check for Kodi
         kodi_markers = [
             Path.home() / ".kodi",
@@ -138,8 +138,8 @@ class RaspberryDetector:
             Path.home() / "script.module.zap2epg",
         ]
         info["kodi_detected"] = any(path.exists() for path in kodi_markers)
-        
+
         # Check for OSMC
         info["osmc_detected"] = Path("/home/osmc").exists()
-        
+
         return info

--- a/gracenote2epg/args/systems/synology.py
+++ b/gracenote2epg/args/systems/synology.py
@@ -8,25 +8,25 @@ and TVheadend path configuration.
 import re
 import logging
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict
 
 
 class SynologyDetector:
     """Synology NAS detection and configuration"""
-    
+
     system_type = "synology"
-    
+
     def detect(self) -> bool:
         """
         Detect if running on Synology NAS
-        
+
         Returns:
             bool: True if Synology system detected
         """
         # Method 1: Check for Synology-specific config file (most reliable)
         if Path("/etc/synoinfo.conf").exists():
             return True
-        
+
         # Method 2: Check VERSION file for Synology content
         try:
             version_file = Path("/etc/VERSION")
@@ -39,28 +39,29 @@ class SynologyDetector:
                         return True
         except Exception:
             pass
-        
+
         # Method 3: Check for TVheadend Synology packages
         if (
             Path("/var/packages/tvheadend/var").exists()
             or Path("/var/packages/tvheadend/target/var").exists()
         ):
             return True
-        
+
         # Method 4: Platform check (fallback)
         try:
             import platform
+
             if "synology" in platform.uname().release.lower():
                 return True
         except Exception:
             pass
-        
+
         return False
-    
+
     def get_dsm_version(self) -> int:
         """
         Get Synology DSM version number
-        
+
         Returns:
             int: Build number (e.g., 50000 for DSM7+, 30000 for DSM6)
         """
@@ -70,18 +71,18 @@ class SynologyDetector:
             if version_file.exists():
                 with open(version_file, "r") as f:
                     content = f.read()
-                
+
                 # Extract major version and build number
                 major_match = re.search(r'majorversion="?(\d+)"?', content)
                 build_match = re.search(r'buildnumber="?(\d+)"?', content)
-                
+
                 if major_match:
                     major_version = int(major_match.group(1))
-                    
+
                     if build_match:
                         # Return actual build number for precise detection
                         return int(build_match.group(1))
-                    
+
                     # Map major version to typical build ranges
                     if major_version >= 7:
                         return 50000  # DSM7+
@@ -91,7 +92,7 @@ class SynologyDetector:
                         return 20000  # DSM5 and older
         except Exception as e:
             logging.debug(f"Error reading DSM version: {e}")
-        
+
         # Check directory structure as fallback
         try:
             # DSM7+ uses new path structure
@@ -108,22 +109,22 @@ class SynologyDetector:
                 return 50000  # Prefer newer structure
         except Exception:
             pass
-        
+
         # Default to DSM7+ if detection fails
         return 50000
-    
+
     def get_base_path(self, home: Path) -> Path:
         """
         Get Synology-specific base path
-        
+
         Args:
             home: User home directory
-            
+
         Returns:
             Path: Base directory for gracenote2epg
         """
         dsm_version = self.get_dsm_version()
-        
+
         # Select path based on DSM version
         if dsm_version < 40000:
             # DSM6 and earlier
@@ -131,13 +132,13 @@ class SynologyDetector:
         else:
             # DSM7 and later
             base_dir = Path("/var/packages/tvheadend/var/epggrab/gracenote2epg")
-        
+
         logging.debug(f"Synology DSM version: {dsm_version}, selected path: {base_dir}")
-        
+
         # Verify parent directory exists
         if not base_dir.parent.exists():
             logging.warning(f"Expected TVheadend path {base_dir.parent} not found")
-            
+
             # Try to find valid TVheadend path
             for check_path in [
                 "/var/packages/tvheadend/var",
@@ -151,13 +152,13 @@ class SynologyDetector:
                 # No TVheadend paths found, fallback to home
                 logging.warning("No TVheadend paths found, using home directory")
                 base_dir = home / "gracenote2epg"
-        
+
         return base_dir
-    
+
     def get_system_info(self) -> Dict:
         """
         Get Synology system information
-        
+
         Returns:
             Dict: System details including DSM version
         """
@@ -167,10 +168,10 @@ class SynologyDetector:
             "dsm_major": None,
             "tvheadend_path": None,
         }
-        
+
         dsm_version = self.get_dsm_version()
         info["dsm_version"] = dsm_version
-        
+
         # Determine DSM major version
         if dsm_version >= 50000:
             info["dsm_major"] = 7
@@ -178,7 +179,7 @@ class SynologyDetector:
             info["dsm_major"] = 6
         else:
             info["dsm_major"] = 5
-        
+
         # Find TVheadend path
         for path in [
             "/var/packages/tvheadend/var",
@@ -187,5 +188,5 @@ class SynologyDetector:
             if Path(path).exists():
                 info["tvheadend_path"] = path
                 break
-        
+
         return info

--- a/gracenote2epg/args/validator.py
+++ b/gracenote2epg/args/validator.py
@@ -11,161 +11,161 @@ from typing import Optional, Tuple
 
 class ArgumentValidator:
     """Validates command-line arguments"""
-    
+
     # Validation patterns
     DAYS_PATTERN = re.compile(r"^[1-9]$|^1[0-4]$")  # 1-14 days
     REFRESH_PATTERN = re.compile(r"^[0-9]+$|^[1-9][0-9]+$")  # 0-999 hours
     CA_CODE_PATTERN = re.compile(r"^[A-Z][0-9][A-Z][ ]?[0-9][A-Z][0-9]$")  # Canadian postal
     US_CODE_PATTERN = re.compile(r"^[0-9]{5}$")  # US ZIP code
-    
+
     @classmethod
     def validate_days(cls, days: Optional[int]) -> Tuple[bool, Optional[str]]:
         """
         Validate days parameter
-        
+
         Args:
             days: Number of days to validate
-            
+
         Returns:
             Tuple of (is_valid, error_message)
         """
         if days is None:
             return True, None
-            
+
         if not cls.DAYS_PATTERN.match(str(days)):
             return False, f"Parameter [--days] must be 1-14, got: {days}"
-            
+
         return True, None
-    
+
     @classmethod
     def validate_offset(cls, offset: Optional[int]) -> Tuple[bool, Optional[str]]:
         """
         Validate offset parameter
-        
+
         Args:
             offset: Offset days to validate
-            
+
         Returns:
             Tuple of (is_valid, error_message)
         """
         if offset is None:
             return True, None
-            
+
         if not cls.DAYS_PATTERN.match(str(offset)):
             return False, f"Parameter [--offset] must be 1-14, got: {offset}"
-            
+
         return True, None
-    
+
     @classmethod
     def validate_refresh(cls, refresh: Optional[int]) -> Tuple[bool, Optional[str]]:
         """
         Validate refresh parameter
-        
+
         Args:
             refresh: Refresh hours to validate
-            
+
         Returns:
             Tuple of (is_valid, error_message)
         """
         if refresh is None:
             return True, None
-            
+
         if refresh < 0 or refresh > 168:  # 0 to 7 days
             return False, f"Parameter [--refresh] must be 0-168 hours, got: {refresh}"
-            
+
         return True, None
-    
+
     @classmethod
     def validate_lineupid(cls, lineupid: Optional[str]) -> Tuple[bool, Optional[str]]:
         """
         Validate lineupid parameter (basic validation)
-        
+
         Args:
             lineupid: Lineup ID to validate
-            
+
         Returns:
             Tuple of (is_valid, error_message)
         """
         if lineupid is None:
             return True, None
-            
+
         lineupid = lineupid.strip()
         if not lineupid:
             return False, "Parameter [--lineupid] cannot be empty"
-            
+
         # Additional validation will be done in ConfigManager
         return True, None
-    
+
     @classmethod
     def validate_location_code(cls, location_code: str) -> Tuple[bool, Optional[str]]:
         """
         Validate US ZIP or Canadian postal code
-        
+
         Args:
             location_code: Location code to validate
-            
+
         Returns:
             Tuple of (is_valid, error_message)
         """
         if not location_code:
             return True, None
-            
+
         # Remove spaces for US ZIP validation
         clean_code = location_code.replace(" ", "")
-        
+
         # Check if valid Canadian or US format
         if cls.CA_CODE_PATTERN.match(location_code) or cls.US_CODE_PATTERN.match(clean_code):
             return True, None
-        
+
         # Normalize display for error message
         display_location = location_code.replace(" ", "")
         return False, (
             f"Invalid location code: {display_location}. "
             "Expected US ZIP (12345) or Canadian postal (A1A1A1)"
         )
-    
+
     @classmethod
     def is_canadian_postal(cls, location_code: str) -> bool:
         """Check if location code is Canadian postal format"""
         return bool(cls.CA_CODE_PATTERN.match(location_code))
-    
+
     @classmethod
     def is_us_zip(cls, location_code: str) -> bool:
         """Check if location code is US ZIP format"""
         clean_code = location_code.replace(" ", "")
         return bool(cls.US_CODE_PATTERN.match(clean_code))
-    
+
     @classmethod
     def validate_all_arguments(cls, args) -> list:
         """
         Validate all arguments at once
-        
+
         Args:
             args: Parsed arguments object
-            
+
         Returns:
             List of error messages (empty if all valid)
         """
         errors = []
-        
+
         # Validate days
-        valid, error = cls.validate_days(getattr(args, 'days', None))
+        valid, error = cls.validate_days(getattr(args, "days", None))
         if not valid:
             errors.append(error)
-        
+
         # Validate offset
-        valid, error = cls.validate_offset(getattr(args, 'offset', None))
+        valid, error = cls.validate_offset(getattr(args, "offset", None))
         if not valid:
             errors.append(error)
-        
+
         # Validate refresh
-        valid, error = cls.validate_refresh(getattr(args, 'refresh', None))
+        valid, error = cls.validate_refresh(getattr(args, "refresh", None))
         if not valid:
             errors.append(error)
-        
+
         # Validate lineupid
-        valid, error = cls.validate_lineupid(getattr(args, 'lineupid', None))
+        valid, error = cls.validate_lineupid(getattr(args, "lineupid", None))
         if not valid:
             errors.append(error)
-            
+
         return errors

--- a/gracenote2epg/cache.py
+++ b/gracenote2epg/cache.py
@@ -43,7 +43,8 @@ class CacheManager:
         """Move legacy flat *.json series files into the series subdirectory."""
         try:
             legacy = [
-                f for f in self.cache_dir.glob("*.json")
+                f
+                for f in self.cache_dir.glob("*.json")
                 if f.is_file() and not f.name.endswith(".json.gz")
             ]
             if not legacy:
@@ -54,9 +55,7 @@ class CacheManager:
                     cache_file.replace(target)
                 except Exception as e:
                     logging.debug("Could not migrate cached series %s: %s", cache_file.name, e)
-            logging.info(
-                "Migrated %d cached series file(s) into %s", len(legacy), self.series_dir
-            )
+            logging.info("Migrated %d cached series file(s) into %s", len(legacy), self.series_dir)
         except Exception as e:
             logging.debug("Legacy series cache migration skipped: %s", e)
 
@@ -401,4 +400,3 @@ class CacheManager:
             )
 
         logging.info("Show cache cleanup completed")
-

--- a/gracenote2epg/config/__init__.py
+++ b/gracenote2epg/config/__init__.py
@@ -9,7 +9,7 @@ Main interface:
 
 The module is organized into specialized components:
     - validation: Configuration validation and consistency checks
-    - settings: XML settings parsing and management  
+    - settings: XML settings parsing and management
     - migration: Configuration migration and cleanup
     - lineup: Lineup ID management and auto-detection
     - retention: Cache and retention policy management
@@ -18,7 +18,7 @@ The module is organized into specialized components:
 
 Usage:
     from gracenote2epg.config import ConfigManager
-    
+
     config_manager = ConfigManager("/path/to/config.xml")
     config = config_manager.load_config()
 """

--- a/gracenote2epg/config/base.py
+++ b/gracenote2epg/config/base.py
@@ -68,9 +68,15 @@ class ConfigManager:
 
         # Override with command line arguments (TEMPORARY for this execution only)
         self._process_command_line_overrides(
-            location_code, location_source, location_extracted_from,
-            days, langdetect, refresh_hours, lineupid,
-            original_zipcode, original_lineupid
+            location_code,
+            location_source,
+            location_extracted_from,
+            days,
+            langdetect,
+            refresh_hours,
+            lineupid,
+            original_zipcode,
+            original_lineupid,
         )
 
         # Validate configuration consistency before processing
@@ -96,17 +102,19 @@ class ConfigManager:
     def _parse_and_migrate_config(self):
         """Parse configuration file and handle migration if needed"""
         # Parse configuration file
-        all_settings, original_order, version = self.settings_manager.parse_config_file(self.config_file)
+        all_settings, original_order, version = self.settings_manager.parse_config_file(
+            self.config_file
+        )
         self.version = version
 
         # Categorize settings and check migration needs
         valid_settings = {
-            k: v for k, v in all_settings.items() 
-            if k in self.validator.VALID_SETTINGS
+            k: v for k, v in all_settings.items() if k in self.validator.VALID_SETTINGS
         }
 
-        migration_needed, deprecated_settings, unknown_settings, ordering_needed = \
+        migration_needed, deprecated_settings, unknown_settings, ordering_needed = (
             self.migrator.analyze_migration_needs(all_settings, valid_settings, original_order)
+        )
 
         # A schema-version bump also needs a rewrite (e.g. to inject the
         # <imagesources> block introduced in version 6).
@@ -134,8 +142,13 @@ class ConfigManager:
                 type(processed_value).__name__,
             )
 
-    def _perform_migration(self, valid_settings: Dict[str, Any], removed_settings: List[str],
-                           ordering_needed: bool, version_upgrade: bool = False):
+    def _perform_migration(
+        self,
+        valid_settings: Dict[str, Any],
+        removed_settings: List[str],
+        ordering_needed: bool,
+        version_upgrade: bool = False,
+    ):
         """Perform configuration migration"""
         reason = []
         if removed_settings:
@@ -150,16 +163,25 @@ class ConfigManager:
         success = self.migrator.perform_migration(
             self.config_file, valid_settings, removed_settings, ordering_needed, version_upgrade
         )
-        
+
         if success:
             # Validate migration result
             if not self.migrator.validate_migration_result(self.config_file):
                 logging.warning("Migration validation failed, attempting rollback")
                 self.migrator.rollback_migration(self.config_file)
 
-    def _process_command_line_overrides(self, location_code, location_source, location_extracted_from,
-                                       days, langdetect, refresh_hours, lineupid,
-                                       original_zipcode, original_lineupid):
+    def _process_command_line_overrides(
+        self,
+        location_code,
+        location_source,
+        location_extracted_from,
+        days,
+        langdetect,
+        refresh_hours,
+        lineupid,
+        original_zipcode,
+        original_lineupid,
+    ):
         """Process command line argument overrides"""
         # Override zipcode
         if location_code:
@@ -172,15 +194,21 @@ class ConfigManager:
             self._process_setting_override("days", str(days), self.settings.get("days", "1"))
 
         if langdetect is not None:
-            self._process_setting_override("langdetect", langdetect, self.settings.get("langdetect", True))
+            self._process_setting_override(
+                "langdetect", langdetect, self.settings.get("langdetect", True)
+            )
 
         if refresh_hours is not None:
-            self._process_setting_override("refresh", str(refresh_hours), self.settings.get("refresh", "48"))
+            self._process_setting_override(
+                "refresh", str(refresh_hours), self.settings.get("refresh", "48")
+            )
 
         if lineupid is not None:
             self._process_setting_override("lineupid", lineupid, original_lineupid)
 
-    def _process_zipcode_override(self, location_code, location_source, location_extracted_from, original_zipcode):
+    def _process_zipcode_override(
+        self, location_code, location_source, location_extracted_from, original_zipcode
+    ):
         """Process zipcode override from command line"""
         if not original_zipcode:  # Empty in config
             if location_source == "extracted" and location_extracted_from:
@@ -188,20 +216,20 @@ class ConfigManager:
                     f"(empty) → {location_code} (extracted from {location_extracted_from})"
                 )
             else:
-                self.config_changes["zipcode"] = (
-                    f"(empty) → {location_code} (from command line)"
-                )
+                self.config_changes["zipcode"] = f"(empty) → {location_code} (from command line)"
         elif original_zipcode != location_code:
             if location_source == "extracted" and location_extracted_from:
                 self.config_changes["zipcode"] = (
                     f"{original_zipcode} → {location_code} (extracted from {location_extracted_from})"
                 )
-                self._handle_zipcode_mismatch(original_zipcode, location_code, location_extracted_from)
+                self._handle_zipcode_mismatch(
+                    original_zipcode, location_code, location_extracted_from
+                )
             else:
                 self.config_changes["zipcode"] = (
                     f"{original_zipcode} → {location_code} (overridden)"
                 )
-        
+
         self.settings["zipcode"] = location_code
 
     def _handle_zipcode_mismatch(self, original_zipcode, location_code, location_extracted_from):
@@ -209,8 +237,13 @@ class ConfigManager:
         normalized_location = location_code.replace(" ", "")
         logging.warning("Configuration mismatch detected and resolved:")
         logging.warning("  Configured zipcode: %s", original_zipcode)
-        logging.warning("  LineupID contains: %s (from %s)", normalized_location, location_extracted_from)
-        logging.warning("  Resolution: Using zipcode from lineupid (%s takes precedence)", location_extracted_from)
+        logging.warning(
+            "  LineupID contains: %s (from %s)", normalized_location, location_extracted_from
+        )
+        logging.warning(
+            "  Resolution: Using zipcode from lineupid (%s takes precedence)",
+            location_extracted_from,
+        )
 
     def _process_setting_override(self, setting_name, new_value, original_value):
         """Process generic setting override"""
@@ -240,7 +273,7 @@ class ConfigManager:
             success = self.migrator.update_config_with_defaults(
                 self.config_file, added_defaults, self.version
             )
-            
+
             if success:
                 # Notify user about upgrade
                 self.migrator.notify_config_upgrade(added_list)
@@ -321,7 +354,9 @@ class ConfigManager:
         logging.info("  description: %s", lineup_config["description"])
         logging.info("  xdetails (download extended data): %s", self.settings.get("xdetails"))
         logging.info("  xdesc (use extended descriptions): %s", self.settings.get("xdesc"))
-        logging.info("  langdetect (automatic language detection): %s", self.settings.get("langdetect"))
+        logging.info(
+            "  langdetect (automatic language detection): %s", self.settings.get("langdetect")
+        )
 
         # Log cache and retention using retention manager
         self.retention_manager.log_retention_summary(retention_config)

--- a/gracenote2epg/config/display.py
+++ b/gracenote2epg/config/display.py
@@ -51,13 +51,15 @@ class ConfigDisplayer:
 
         return True
 
-    def _display_lineup_output(self,
-                              postal_code: str,
-                              clean_postal: str,
-                              country_name: str,
-                              country: str,
-                              lineup_config: Dict,
-                              debug_mode: bool = False):
+    def _display_lineup_output(
+        self,
+        postal_code: str,
+        clean_postal: str,
+        country_name: str,
+        country: str,
+        lineup_config: Dict,
+        debug_mode: bool = False,
+    ):
         """
         Display lineup detection output - unified function for both simple and debug modes
 
@@ -81,55 +83,61 @@ class ConfigDisplayer:
             print("=" * 70)
             print("GRACENOTE2EPG - LINEUP DETECTION (DEBUG MODE)")
             print("=" * 70)
-            print(f"📍 LOCATION INFORMATION:")
+            print("📍 LOCATION INFORMATION:")
             print(f"   Normalized code:   {clean_postal}")
             print(f"   Detected country:  {country_name} ({country})")
             print()
 
         # API parameters
-        print(f"🌍 GRACENOTE API URL PARAMETERS:")
+        print("🌍 GRACENOTE API URL PARAMETERS:")
         print(f"   lineupId={lineup_config['api_lineup_id']}")
         print(f"   country={country}")
         print(f"   postalCode={clean_postal}")
         print()
 
         # Validation URLs - SIMPLIFIED AND CONSISTENT
-        print(f"✅ VALIDATION URLs:")
-        
+        print("✅ VALIDATION URLs:")
+
         # Check if location was resolved automatically
-        if lineup_config.get('location_source') == 'auto_resolved':
+        if lineup_config.get("location_source") == "auto_resolved":
             print(f"   Direct URL: {lineup_config['tvtv_url']}")
-            print(f"   Status: ✅ Location automatically resolved ({lineup_config.get('resolved_city')}, {lineup_config.get('resolved_province')})")
+            print(
+                f"   Status: ✅ Location automatically resolved ({lineup_config.get('resolved_city')}, {lineup_config.get('resolved_province')})"
+            )
         else:
-            print(f"   Status: ⚠️  {lineup_config.get('manual_lookup_message', 'Unable to automatically resolve location')}")
-            print(f"   Manual lookup required:")
+            print(
+                f"   Status: ⚠️  {lineup_config.get('manual_lookup_message', 'Unable to automatically resolve location')}"
+            )
+            print("   Manual lookup required:")
 
         # Always show manual lookup steps
         try:
             validation_urls = self.lineup_manager.generate_validation_urls(clean_postal, country)
             for instruction in validation_urls["instructions"]:
                 print(f"     {instruction}")
-        except Exception as e:
+        except Exception:
             # Fallback manual instructions
             if country == "CAN":
-                print(f"     1. Go to https://www.tvtv.ca/")
+                print("     1. Go to https://www.tvtv.ca/")
                 print(f"     2. Enter postal code: {clean_postal}")
             else:
-                print(f"     1. Go to https://www.tvtv.us/")
+                print("     1. Go to https://www.tvtv.us/")
                 print(f"     2. Enter ZIP code: {clean_postal}")
-            print(f"     3. Click 'Broadcast' → 'Local Over the Air'")
+            print("     3. Click 'Broadcast' → 'Local Over the Air'")
             print(f"     4. Look for 'lu{lineup_config['tvtv_lineup_id']}' in the URL")
 
         print()
 
         # API test URL
         test_url = self.lineup_manager.generate_gracenote_api_url(lineup_config, int(example_time))
-        print(f"🔗 GRACENOTE API URL FOR TESTING:")
+        print("🔗 GRACENOTE API URL FOR TESTING:")
 
         if debug_mode:
             # Show the human-readable time for debugging
-            print(f"   Using current block: {standard_dt.strftime('%Y-%m-%d %H:00')} "
-                  f"(timestamp: {example_time})")
+            print(
+                f"   Using current block: {standard_dt.strftime('%Y-%m-%d %H:00')} "
+                f"(timestamp: {example_time})"
+            )
 
         print(f"   {test_url}")
         print()
@@ -142,57 +150,59 @@ class ConfigDisplayer:
         print("📖 DOCUMENTATION:")
         print("   https://github.com/th0ma7/gracenote2epg/blob/main/docs/lineup-configuration.md")
 
-    def _display_debug_sections(self, country: str, lineup_config: Dict, clean_postal: str, test_url: str):
+    def _display_debug_sections(
+        self, country: str, lineup_config: Dict, clean_postal: str, test_url: str
+    ):
         """Display debug-only sections for detailed mode"""
-        print(f"📊 GRACENOTE API - OTHER COMMON PARAMETERS:")
+        print("📊 GRACENOTE API - OTHER COMMON PARAMETERS:")
         print(
-            f"   • &device=[-|X]                    "
-            f"Device type: - for Over-the-Air, X for cable/satellite"
+            "   • &device=[-|X]                    "
+            "Device type: - for Over-the-Air, X for cable/satellite"
         )
         print(
-            f"   • &pref=16%2C128                   "
-            f"Preference codes (16,128): channel lineup preferences"
+            "   • &pref=16%2C128                   "
+            "Preference codes (16,128): channel lineup preferences"
         )
         print(
-            f"   • &timezone=America%2FNew_York     "
-            f"User timezone for schedule times (URL-encoded)"
+            "   • &timezone=America%2FNew_York     "
+            "User timezone for schedule times (URL-encoded)"
         )
-        print(f"   • &languagecode=en-us              Content language: en-us, fr-ca, es-us, etc.")
+        print("   • &languagecode=en-us              Content language: en-us, fr-ca, es-us, etc.")
         print(
-            f"   • &TMSID=                          "
-            f"Tribune Media Services ID (legacy, usually empty)"
+            "   • &TMSID=                          "
+            "Tribune Media Services ID (legacy, usually empty)"
         )
         print(
-            f"   • &AffiliateID=lat                 "
-            f"Partner/affiliate identifier (lat=local affiliate)"
+            "   • &AffiliateID=lat                 "
+            "Partner/affiliate identifier (lat=local affiliate)"
         )
         print()
 
-        print(f"💾 MANUAL DOWNLOAD:")
-        print(f"⚠️  NOTE: Using browser-like headers to bypass AWS WAF")
+        print("💾 MANUAL DOWNLOAD:")
+        print("⚠️  NOTE: Using browser-like headers to bypass AWS WAF")
         print()
         print(
-            f'curl -s -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
-            f'AppleWebKit/537.36" \\'
+            'curl -s -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+            'AppleWebKit/537.36" \\'
         )
-        print(f'     -H "Accept: application/json, text/html, application/xhtml+xml, */*" \\')
+        print('     -H "Accept: application/json, text/html, application/xhtml+xml, */*" \\')
         print(f'     "{test_url}" > out.json')
         print()
 
-        print(f"🔧 RECOMMENDED CONFIGURATION:")
+        print("🔧 RECOMMENDED CONFIGURATION:")
         country_full = "Canada" if country == "CAN" else "United States"
-        print(f"   <!-- Simplified configuration (auto-detection) -->")
+        print("   <!-- Simplified configuration (auto-detection) -->")
         print(f'   <setting id="zipcode">{clean_postal}</setting>')
-        print(f'   <setting id="lineupid">auto</setting>')
+        print('   <setting id="lineupid">auto</setting>')
         print()
-        print(f"   <!-- Alternative: Copy tvtv.com lineup ID directly -->")
+        print("   <!-- Alternative: Copy tvtv.com lineup ID directly -->")
         print(f"   <!-- <setting id=\"lineupid\">{lineup_config['tvtv_lineup_id']}</setting> -->")
         print()
-        print(f"   <!-- For Cable/Satellite providers: -->")
+        print("   <!-- For Cable/Satellite providers: -->")
         print(f'   <!-- <setting id="lineupid">{country}-[ProviderID]-X</setting> -->')
         print(
             f'   <!-- Example: <setting id="lineupid">{country}-0005993-X</setting> '
-            f'for Videotron -->'
+            f"for Videotron -->"
         )
         print()
 
@@ -206,12 +216,17 @@ class ConfigDisplayer:
         print("=" * 70)
         print()
 
-    def display_config_summary(self, settings: Dict[str, Any], lineup_config: Dict[str, str], 
-                              retention_config: Dict[str, Any], config_changes: Dict[str, str]):
+    def display_config_summary(
+        self,
+        settings: Dict[str, Any],
+        lineup_config: Dict[str, str],
+        retention_config: Dict[str, Any],
+        config_changes: Dict[str, str],
+    ):
         """Display comprehensive configuration summary"""
         print("Configuration Summary:")
         print("=" * 50)
-        
+
         # Enhanced zipcode logging with cleaner format
         zipcode = settings.get("zipcode")
         if "zipcode" in config_changes:
@@ -246,11 +261,14 @@ class ConfigDisplayer:
         # Cache and retention
         self._display_cache_retention_summary(settings, retention_config)
 
-    def _display_cache_retention_summary(self, settings: Dict[str, Any], retention_config: Dict[str, Any]):
+    def _display_cache_retention_summary(
+        self, settings: Dict[str, Any], retention_config: Dict[str, Any]
+    ):
         """Display cache and retention policy summary"""
         from .retention import RetentionManager
+
         retention_manager = RetentionManager()
-        
+
         refresh_hours = retention_manager.get_refresh_hours(settings)
         redays = retention_manager.get_cache_retention_days(settings)
 
@@ -258,7 +276,9 @@ class ConfigDisplayer:
         if refresh_hours == 0:
             print("  refresh: disabled (use all cached data)")
         else:
-            print(f"  refresh: {refresh_hours} hours (refresh first {refresh_hours} hours of guide)")
+            print(
+                f"  refresh: {refresh_hours} hours (refresh first {refresh_hours} hours of guide)"
+            )
 
         print(f"  redays: {redays} days (cache retention period)")
 
@@ -270,7 +290,9 @@ class ConfigDisplayer:
         else:
             print("  logrotate: disabled")
 
-        print(f"  rexmltv: {retention_config['xmltv_retention_days']} days (XMLTV backup retention)")
+        print(
+            f"  rexmltv: {retention_config['xmltv_retention_days']} days (XMLTV backup retention)"
+        )
 
     def display_feature_logic(self, settings: Dict[str, Any]):
         """Display configuration logic explanation"""
@@ -296,10 +318,11 @@ class ConfigDisplayer:
     def display_optimization_recommendations(self, settings: Dict[str, Any]):
         """Display optimization recommendations if any"""
         from .retention import RetentionManager
+
         retention_manager = RetentionManager()
-        
+
         recommendations = retention_manager.optimize_retention_settings(settings)
-        
+
         if recommendations:
             print()
             print("💡 OPTIMIZATION RECOMMENDATIONS:")

--- a/gracenote2epg/config/lineup.py
+++ b/gracenote2epg/config/lineup.py
@@ -8,7 +8,7 @@ and validation URL generation for gracenote2epg configurations.
 import logging
 import re
 import sys
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 from ..geocoding import Geocoder
 
@@ -28,8 +28,8 @@ class LineupManager:
         """Check if we should output debug to console (--show-lineup + --debug)"""
         # Check if we're in show-lineup mode with debug
         args = sys.argv
-        has_show_lineup = any('--show-lineup' in arg for arg in args)
-        has_debug = any('--debug' in arg for arg in args)
+        has_show_lineup = any("--show-lineup" in arg for arg in args)
+        has_debug = any("--debug" in arg for arg in args)
 
         # Check if logging has console handlers configured
         root_logger = logging.getLogger()
@@ -82,12 +82,30 @@ class LineupManager:
     def _remove_accents(self, text: str) -> str:
         """Remove French accents for URL normalization"""
         accent_map = {
-            'à': 'a', 'á': 'a', 'â': 'a', 'ã': 'a', 'ä': 'a',
-            'è': 'e', 'é': 'e', 'ê': 'e', 'ë': 'e',
-            'ì': 'i', 'í': 'i', 'î': 'i', 'ï': 'i',
-            'ò': 'o', 'ó': 'o', 'ô': 'o', 'õ': 'o', 'ö': 'o',
-            'ù': 'u', 'ú': 'u', 'û': 'u', 'ü': 'u',
-            'ç': 'c', 'ñ': 'n'
+            "à": "a",
+            "á": "a",
+            "â": "a",
+            "ã": "a",
+            "ä": "a",
+            "è": "e",
+            "é": "e",
+            "ê": "e",
+            "ë": "e",
+            "ì": "i",
+            "í": "i",
+            "î": "i",
+            "ï": "i",
+            "ò": "o",
+            "ó": "o",
+            "ô": "o",
+            "õ": "o",
+            "ö": "o",
+            "ù": "u",
+            "ú": "u",
+            "û": "u",
+            "ü": "u",
+            "ç": "c",
+            "ñ": "n",
         }
 
         for accented, unaccented in accent_map.items():
@@ -98,7 +116,7 @@ class LineupManager:
     def _get_province_code_for_url(self, province_code: str, country: str) -> str:
         """Convert province code to tvtv URL format (lowercase)"""
         if not province_code:
-            return 'qc' if country == "CAN" else 'ca'
+            return "qc" if country == "CAN" else "ca"
 
         # For URL, we need lowercase
         return province_code.lower()
@@ -151,7 +169,7 @@ class LineupManager:
             "resolved_province": province_code,
             "location_source": status,
             # Always provide manual lookup instructions as fallback
-            "manual_lookup_message": f"Unable to automatically resolve location for {postal_code}. Please use manual lookup instructions below."
+            "manual_lookup_message": f"Unable to automatically resolve location for {postal_code}. Please use manual lookup instructions below.",
         }
 
     def normalize_lineup_id(self, lineupid: str, country: str, postal_code: str) -> str:
@@ -288,7 +306,7 @@ class LineupManager:
                 f"2. Enter postal code: {formatted_postal}",
                 f"3a. For OTA: Click 'Broadcast' → 'Local Over the Air' → Look for 'lu{lineup_config['tvtv_lineup_id']}' in URL",
                 f"3b. For Cable/Sat: Select your provider → Look for 'lu{country}-[ProviderID]-X' in URL",
-                f"4. Expected OTA pattern: lu{lineup_config['tvtv_lineup_id']}"
+                f"4. Expected OTA pattern: lu{lineup_config['tvtv_lineup_id']}",
             ]
         else:
             base_url = "https://www.tvtv.us/"
@@ -297,15 +315,15 @@ class LineupManager:
                 f"2. Enter ZIP code: {postal_code}",
                 f"3a. For OTA: Click 'Broadcast' → 'Local Over the Air' → Look for 'lu{lineup_config['tvtv_lineup_id']}' in URL",
                 f"3b. For Cable/Sat: Select your provider → Look for 'lu{country}-[ProviderID]-X' in URL",
-                f"4. Expected OTA pattern: lu{lineup_config['tvtv_lineup_id']}"
+                f"4. Expected OTA pattern: lu{lineup_config['tvtv_lineup_id']}",
             ]
 
         return {
             "base_url": base_url,
-            "auto_generated_url": lineup_config['tvtv_url'],
+            "auto_generated_url": lineup_config["tvtv_url"],
             "instructions": instructions,
-            "tvtv_lineup_id": lineup_config['tvtv_lineup_id'],
-            "expected_pattern": f"lu{lineup_config['tvtv_lineup_id']}"
+            "tvtv_lineup_id": lineup_config["tvtv_lineup_id"],
+            "expected_pattern": f"lu{lineup_config['tvtv_lineup_id']}",
         }
 
     def _format_postal_for_display(self, postal_code: str, country: str = None) -> str:
@@ -326,44 +344,44 @@ class LineupManager:
             Dictionary with configuration recommendations
         """
         lineup_config = self.get_auto_lineup_config(postal_code, country)
-        formatted_postal = self._format_postal_for_display(postal_code, country)
+        self._format_postal_for_display(postal_code, country)
 
         return {
             "auto_detection": {
                 "zipcode": postal_code,
                 "lineupid": "auto",
-                "comment": "Simplified configuration (auto-detection)"
+                "comment": "Simplified configuration (auto-detection)",
             },
             "explicit_ota": {
                 "zipcode": postal_code,
-                "lineupid": lineup_config['tvtv_lineup_id'],
-                "comment": "Alternative: Copy tvtv.com lineup ID directly"
+                "lineupid": lineup_config["tvtv_lineup_id"],
+                "comment": "Alternative: Copy tvtv.com lineup ID directly",
             },
             "cable_satellite_example": {
                 "zipcode": postal_code,
                 "lineupid": f"{country}-[ProviderID]-X",
-                "comment": f"For Cable/Satellite providers",
-                "example": f"{country}-0005993-X for Videotron" if country == "CAN" else f"{country}-0012345-X for Comcast"
-            }
+                "comment": "For Cable/Satellite providers",
+                "example": (
+                    f"{country}-0005993-X for Videotron"
+                    if country == "CAN"
+                    else f"{country}-0012345-X for Comcast"
+                ),
+            },
         }
 
     def log_lineup_detection(self, original_lineupid: str, final_config: Dict[str, str]):
         """Log lineup detection results for debugging"""
         if final_config["auto_detected"]:
             logging.info(
-                "Auto-detected lineupID: %s → %s",
-                original_lineupid,
-                final_config["lineup_id"]
+                "Auto-detected lineupID: %s → %s", original_lineupid, final_config["lineup_id"]
             )
         else:
             logging.info(
-                "Normalized lineupID: %s → %s",
-                original_lineupid,
-                final_config["lineup_id"]
+                "Normalized lineupID: %s → %s", original_lineupid, final_config["lineup_id"]
             )
 
         logging.debug(
             "Lineup details: device=%s, description='%s'",
             final_config["device_type"],
-            final_config["description"]
+            final_config["description"],
         )

--- a/gracenote2epg/config/migration.py
+++ b/gracenote2epg/config/migration.py
@@ -35,13 +35,15 @@ class ConfigMigrator:
     def __init__(self):
         self._backup_file_created: str = None
 
-    def analyze_migration_needs(self, 
-                               all_settings: Dict[str, Any], 
-                               valid_settings: Dict[str, Any],
-                               original_order: List[str]) -> Tuple[bool, List[str], List[str], bool]:
+    def analyze_migration_needs(
+        self,
+        all_settings: Dict[str, Any],
+        valid_settings: Dict[str, Any],
+        original_order: List[str],
+    ) -> Tuple[bool, List[str], List[str], bool]:
         """
         Analyze what migration operations are needed
-        
+
         Returns:
             tuple: (migration_needed, deprecated_settings, unknown_settings, ordering_needed)
         """
@@ -77,6 +79,7 @@ class ConfigMigrator:
 
         # Check if ordering needs to be corrected (this would be done by SettingsManager)
         from .settings import SettingsManager
+
         settings_manager = SettingsManager()
         ordering_needed = settings_manager.check_ordering_needed(original_order, valid_settings)
 
@@ -86,7 +89,7 @@ class ConfigMigrator:
         """Create backup of configuration file before migration"""
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         backup_file = f"{config_file}.backup.{timestamp}"
-        
+
         try:
             shutil.copy2(config_file, backup_file)
             logging.info("Created configuration backup: %s", backup_file)
@@ -96,12 +99,14 @@ class ConfigMigrator:
             logging.error("Failed to create backup: %s", str(e))
             raise
 
-    def perform_migration(self,
-                         config_file: Path,
-                         valid_settings: Dict[str, Any],
-                         removed_settings: List[str],
-                         ordering_needed: bool = False,
-                         version_upgrade: bool = False) -> bool:
+    def perform_migration(
+        self,
+        config_file: Path,
+        valid_settings: Dict[str, Any],
+        removed_settings: List[str],
+        ordering_needed: bool = False,
+        version_upgrade: bool = False,
+    ) -> bool:
         """
         Perform configuration migration with backup
 
@@ -110,12 +115,12 @@ class ConfigMigrator:
         """
         try:
             # Create backup only if we're making changes
-            backup_file = None
             if removed_settings or ordering_needed or version_upgrade:
-                backup_file = self.create_backup(config_file)
+                self.create_backup(config_file)
 
             # Write cleaned and ordered configuration
             from .settings import SettingsManager
+
             settings_manager = SettingsManager()
             settings_manager.write_clean_config(config_file, valid_settings)
 
@@ -132,6 +137,7 @@ class ConfigMigrator:
                 logging.info("  Removed settings: %s", ", ".join(removed_settings))
 
             from .settings import SettingsManager
+
             logging.info("  Updated to configuration version %s", SettingsManager.CONFIG_VERSION)
 
             # User notification about cleanup/migration - simplified
@@ -145,42 +151,24 @@ class ConfigMigrator:
             logging.error("Continuing with existing configuration...")
             return False
 
-    def update_config_with_defaults(self, 
-                                   config_file: Path, 
-                                   new_settings: Dict[str, Any],
-                                   version: str) -> bool:
+    def update_config_with_defaults(
+        self, config_file: Path, new_settings: Dict[str, Any], version: str
+    ) -> bool:
         """
         Update configuration file to include newly added default settings
-        
+
         Returns:
             bool: True if update was successful
         """
         try:
             # Re-read the original config file to get the unmodified values
             import xml.etree.ElementTree as ET
+
             tree = ET.parse(config_file)
             root = tree.getroot()
 
-            # Get existing settings to preserve their ORIGINAL values
-            existing_settings = {}
-            for setting in root.findall("setting"):
-                setting_id = setting.get("id")
-
-                # Get value based on version (same logic as in SettingsManager)
-                if version == "2":
-                    setting_value = setting.text
-                else:
-                    setting_value = setting.get("value")
-                    if setting_value is None:
-                        setting_value = setting.text
-                    if setting_value == "":
-                        setting_value = None
-
-                # Only include valid settings that we want to preserve
-                from .validation import ConfigValidator
-                validator = ConfigValidator()
-                if setting_id in validator.VALID_SETTINGS:
-                    existing_settings[setting_id] = setting_value
+            # Preserve existing valid settings with their ORIGINAL values
+            existing_settings = self._read_existing_valid_settings(root, version)
 
             # Add only the truly new settings (those not in original file)
             for key, value in new_settings.items():
@@ -196,6 +184,7 @@ class ConfigMigrator:
 
             # Write the complete configuration with preserved original values
             from .settings import SettingsManager
+
             settings_manager = SettingsManager()
             settings_manager.write_clean_config(config_file, existing_settings)
 
@@ -211,11 +200,36 @@ class ConfigMigrator:
             logging.error("Error updating configuration file with defaults: %s", str(e))
             return False
 
+    @staticmethod
+    def _setting_value(setting, version: str):
+        """Extract a <setting>'s value honouring the config schema version."""
+        if version == "2":
+            return setting.text
+        value = setting.get("value")
+        if value is None:
+            value = setting.text
+        if value == "":
+            value = None
+        return value
+
+    def _read_existing_valid_settings(self, root, version: str) -> Dict[str, Any]:
+        """Read valid settings (with their original values) from a parsed config."""
+        from .validation import ConfigValidator
+
+        valid = ConfigValidator().VALID_SETTINGS
+        existing = {}
+        for setting in root.findall("setting"):
+            setting_id = setting.get("id")
+            if setting_id in valid:
+                existing[setting_id] = self._setting_value(setting, version)
+        return existing
+
     def notify_config_upgrade(self, added_defaults: List[str]):
         """Notify user about configuration upgrade with visible warning"""
         backup_file = self._backup_file_created
 
         from .settings import SettingsManager
+
         logging.warning("=" * 60)
         logging.warning("CONFIGURATION UPGRADED TO VERSION %s", SettingsManager.CONFIG_VERSION)
         if backup_file:
@@ -237,29 +251,31 @@ class ConfigMigrator:
         """Validate that migration was successful by attempting to parse the result"""
         try:
             import xml.etree.ElementTree as ET
+
             tree = ET.parse(config_file)
             root = tree.getroot()
-            
+
             # Basic validation
             if root.tag != "settings":
                 logging.error("Migration validation failed: root element is not 'settings'")
                 return False
-                
+
             from .settings import SettingsManager
+
             if root.attrib.get("version") != SettingsManager.CONFIG_VERSION:
                 logging.warning(
                     "Migration validation: version is not '%s'", SettingsManager.CONFIG_VERSION
                 )
-                
+
             # Count settings
             settings_count = len(root.findall("setting"))
             if settings_count == 0:
                 logging.error("Migration validation failed: no settings found")
                 return False
-                
+
             logging.debug("Migration validation passed: %d settings found", settings_count)
             return True
-            
+
         except Exception as e:
             logging.error("Migration validation failed: %s", str(e))
             return False
@@ -269,17 +285,17 @@ class ConfigMigrator:
         if not self._backup_file_created:
             logging.error("Cannot rollback: no backup file available")
             return False
-            
+
         try:
             backup_path = Path(self._backup_file_created)
             if not backup_path.exists():
                 logging.error("Cannot rollback: backup file not found: %s", backup_path)
                 return False
-                
+
             shutil.copy2(backup_path, config_file)
             logging.info("Configuration rolled back from backup: %s", backup_path)
             return True
-            
+
         except Exception as e:
             logging.error("Failed to rollback configuration: %s", str(e))
             return False

--- a/gracenote2epg/config/retention.py
+++ b/gracenote2epg/config/retention.py
@@ -168,7 +168,7 @@ class RetentionManager:
         xmltv_retention = retention_config.get("xmltv_retention_days", 7)
 
         logging.info("Cache and retention policies:")
-        
+
         if retention_config.get("enabled", False):
             logging.info(
                 "  logrotate: enabled (%s, %d days retention)",
@@ -178,10 +178,7 @@ class RetentionManager:
         else:
             logging.info("  logrotate: disabled")
 
-        logging.info(
-            "  rexmltv: %d days (XMLTV backup retention)", 
-            xmltv_retention
-        )
+        logging.info("  rexmltv: %d days (XMLTV backup retention)", xmltv_retention)
 
         # Log final cache and retention policy status for transparency
         if retention_config.get("enabled", False):
@@ -224,37 +221,37 @@ class RetentionManager:
     def optimize_retention_settings(self, settings: Dict[str, Any]) -> Dict[str, str]:
         """
         Analyze retention settings and provide optimization recommendations
-        
+
         Returns:
             Dict with optimization recommendations
         """
         recommendations = {}
-        
+
         days = int(settings.get("days", "1"))
         redays = int(settings.get("redays", str(days)))
         refresh_hours = self._get_refresh_hours(settings)
-        
+
         # Cache optimization
         if redays > days * 7:  # Much higher than needed
             recommendations["redays"] = (
                 f"Consider reducing redays from {redays} to {days * 2} "
                 f"for better disk usage (current setting keeps {redays - days} extra days)"
             )
-            
+
         if refresh_hours > 72:  # Very high refresh
             recommendations["refresh"] = (
                 f"Consider reducing refresh from {refresh_hours}h to 48h "
                 f"for more current data (current setting may use stale data)"
             )
-            
+
         # Retention optimization
         retention_config = self.get_retention_config(settings)
         log_retention = retention_config.get("log_retention_days", 30)
-        
+
         if log_retention > 90:  # Very long log retention
             recommendations["relogs"] = (
                 f"Consider reducing log retention from {log_retention} to 30 days "
                 f"for better disk usage"
             )
-            
+
         return recommendations

--- a/gracenote2epg/config/settings.py
+++ b/gracenote2epg/config/settings.py
@@ -122,7 +122,7 @@ class SettingsManager:
     def parse_config_file(self, config_file: Path) -> tuple[Dict[str, Any], List[str], str]:
         """
         Parse XML configuration file
-        
+
         Returns:
             tuple: (valid_settings, all_settings_order, version)
         """
@@ -167,7 +167,9 @@ class SettingsManager:
             logging.error("Error reading configuration file %s: %s", config_file, e)
             raise
 
-    def check_ordering_needed(self, original_order: List[str], valid_settings: Dict[str, str]) -> bool:
+    def check_ordering_needed(
+        self, original_order: List[str], valid_settings: Dict[str, str]
+    ) -> bool:
         """Check if configuration settings need to be reordered"""
         # Filter original order to only include valid settings
         current_valid_order = [

--- a/gracenote2epg/config/validation.py
+++ b/gracenote2epg/config/validation.py
@@ -93,10 +93,10 @@ class ConfigValidator:
     def validate_config_consistency(self, settings: Dict[str, Any]) -> Dict[str, str]:
         """
         Validate configuration consistency between zipcode and lineupid
-        
+
         Args:
             settings: Configuration settings dictionary
-            
+
         Returns:
             Dict with any changes made for consistency
         """
@@ -140,9 +140,7 @@ class ConfigValidator:
                 # Lineupid contains location but no zipcode configured - auto-extract
                 normalized_extracted = extracted_location.replace(" ", "")
                 settings["zipcode"] = normalized_extracted
-                changes["zipcode"] = (
-                    f"(empty) → {normalized_extracted} (extracted from {lineupid})"
-                )
+                changes["zipcode"] = f"(empty) → {normalized_extracted} (extracted from {lineupid})"
                 logging.info(
                     "Auto-extracted zipcode from lineupid: %s → %s", lineupid, normalized_extracted
                 )

--- a/gracenote2epg/downloader/__init__.py
+++ b/gracenote2epg/downloader/__init__.py
@@ -6,11 +6,11 @@ intelligent caching, and specialized downloaders for guide and series data.
 """
 
 from .base import OptimizedDownloader
-from .guide import GuideDownloader  
+from .guide import GuideDownloader
 from .series import SeriesDownloader
 
 __all__ = [
     "OptimizedDownloader",
-    "GuideDownloader", 
+    "GuideDownloader",
     "SeriesDownloader",
 ]

--- a/gracenote2epg/downloader/base.py
+++ b/gracenote2epg/downloader/base.py
@@ -386,8 +386,6 @@ class DownloaderStatsMixin:
             "total": self.downloaded_count + self.cached_count + self.failed_count,
             "success_rate": self._calculate_success_rate(),
             "cache_efficiency": (
-                (self.cached_count / cached_or_downloaded * 100)
-                if cached_or_downloaded > 0
-                else 0
+                (self.cached_count / cached_or_downloaded * 100) if cached_or_downloaded > 0 else 0
             ),
         }

--- a/gracenote2epg/downloader/guide.py
+++ b/gracenote2epg/downloader/guide.py
@@ -8,7 +8,7 @@ refresh logic, and comprehensive statistics reporting.
 import logging
 import time
 import urllib.parse
-from typing import Dict, Optional
+from typing import Dict
 
 from .base import OptimizedDownloader, DownloaderStatsMixin
 from ..cache import CacheManager
@@ -17,47 +17,48 @@ from ..utils import TimeUtils
 
 class GuideDownloader(DownloaderStatsMixin):
     """Downloads TV guide data blocks with intelligent caching"""
-    
+
     def __init__(self, http_engine: OptimizedDownloader, cache_manager: CacheManager):
         self.http_engine = http_engine
         self.cache_manager = cache_manager
         self.base_url = "http://tvlistings.gracenote.com/api/grid"
-        
+
         # Statistics
         self.downloaded_count = 0
         self.cached_count = 0
         self.failed_count = 0
-        
-    def download_guide_blocks(self, grid_time_start: float, day_hours: int, 
-                             lineup_config: Dict, refresh_hours: int = 48) -> bool:
+
+    def download_guide_blocks(
+        self, grid_time_start: float, day_hours: int, lineup_config: Dict, refresh_hours: int = 48
+    ) -> bool:
         """
         Download guide blocks with intelligent caching
-        
+
         Args:
             grid_time_start: Start time for guide
             day_hours: Number of 3-hour blocks to download
             lineup_config: Lineup configuration from config manager
             refresh_hours: Hours to refresh from cache
-            
+
         Returns:
             bool: True if successful (80%+ blocks available)
         """
         logging.info("Starting guide download with intelligent caching")
         logging.info("  Refresh window: first %d hours will be re-downloaded", refresh_hours)
         logging.info("  Guide duration: %d blocks (%d hours)", day_hours, day_hours * 3)
-        
+
         self._log_lineup_config(lineup_config)
-        
+
         # Reset statistics
         self.downloaded_count = 0
         self.cached_count = 0
         self.failed_count = 0
-        
+
         # Download each block
         grid_time = grid_time_start
         for block_num in range(day_hours):
             success = self._download_single_block(grid_time, lineup_config, refresh_hours)
-            
+
             if success:
                 # Determine if it was downloaded or cached
                 time_from_now = grid_time - time.time()
@@ -67,28 +68,29 @@ class GuideDownloader(DownloaderStatsMixin):
                     self.cached_count += 1
             else:
                 self.failed_count += 1
-                
+
             grid_time += 10800  # Next 3-hour block
-            
+
         # Log statistics
         self._log_statistics()
-        
+
         return self._calculate_success_rate() >= 80
-    
-    def _download_single_block(self, grid_time: float, lineup_config: Dict, 
-                              refresh_hours: int) -> bool:
+
+    def _download_single_block(
+        self, grid_time: float, lineup_config: Dict, refresh_hours: int
+    ) -> bool:
         """Download a single guide block with caching logic"""
         # Generate filename
         filename = TimeUtils.guide_block_filename(grid_time)
-        
+
         # Build URL
         url = self._build_gracenote_url(lineup_config, grid_time)
-        
+
         # Download with cache logic
         return self.cache_manager.download_guide_block_safe(
             self.http_engine, grid_time, filename, url, refresh_hours
         )
-    
+
     def _build_gracenote_url(self, lineup_config: Dict, grid_time: float) -> str:
         """Build Gracenote API URL with proper parameter ordering"""
         params = [
@@ -106,12 +108,12 @@ class GuideDownloader(DownloaderStatsMixin):
             ("pref", "-"),
             ("userId", "-"),
         ]
-        
+
         query_string = "&".join(
             [f"{key}={urllib.parse.quote(str(value))}" for key, value in params]
         )
         return f"{self.base_url}?{query_string}"
-    
+
     def _log_lineup_config(self, lineup_config: Dict):
         """Log lineup configuration details"""
         if lineup_config["auto_detected"]:
@@ -127,12 +129,12 @@ class GuideDownloader(DownloaderStatsMixin):
                 lineup_config["lineup_id"],
                 lineup_config["device_type"],
             )
-    
+
     def _log_statistics(self):
         """Log comprehensive download statistics"""
         total = self.downloaded_count + self.cached_count + self.failed_count
         success_rate = self._calculate_success_rate()
-        
+
         logging.info("Guide download completed:")
         logging.info(
             "  Blocks: %d total (%d downloaded, %d cached, %d failed)",
@@ -141,14 +143,17 @@ class GuideDownloader(DownloaderStatsMixin):
             self.cached_count,
             self.failed_count,
         )
-        
+
         if total > 0:
-            cache_efficiency = (self.cached_count / total * 100)
+            cache_efficiency = self.cached_count / total * 100
             logging.info("  Cache efficiency: %.1f%% reused", cache_efficiency)
-            
+
         logging.info("  Success rate: %.1f%%", success_rate)
-        
+
         # Log HTTP engine statistics
         http_stats = self.http_engine.get_statistics()
-        logging.debug("  HTTP requests: %d total, %d WAF blocks", 
-                     http_stats["total_requests"], http_stats["waf_blocks"])
+        logging.debug(
+            "  HTTP requests: %d total, %d WAF blocks",
+            http_stats["total_requests"],
+            http_stats["waf_blocks"],
+        )

--- a/gracenote2epg/downloader/series.py
+++ b/gracenote2epg/downloader/series.py
@@ -15,61 +15,61 @@ from ..cache import CacheManager
 
 class SeriesDownloader(DownloaderStatsMixin):
     """Downloads extended series details with intelligent caching"""
-    
+
     def __init__(self, http_engine: OptimizedDownloader, cache_manager: CacheManager):
         self.http_engine = http_engine
         self.cache_manager = cache_manager
         self.base_url = "https://tvlistings.gracenote.com/api/program/overviewDetails"
-        
+
         # Statistics
         self.downloaded_count = 0
         self.cached_count = 0
         self.failed_count = 0
         self.failed_series: List[str] = []
         self.cached_series: Set[str] = set()
-        
+
     def download_series_details(self, series_list: List[str]) -> bool:
         """
         Download extended details for series with intelligent caching
-        
+
         Args:
             series_list: List of series IDs to download
-            
+
         Returns:
             bool: True if 70%+ successful
         """
         logging.info("Starting extended series details download")
-        
+
         # Reset statistics
         self.downloaded_count = 0
         self.cached_count = 0
         self.failed_count = 0
         self.failed_series.clear()
         self.cached_series.clear()
-        
+
         # Get unique series and identify what needs downloading
         unique_series = set(series_list)
         to_download = self._identify_series_to_download(unique_series)
-        
+
         logging.info(
             "Extended details: %d unique series found, %d downloads needed",
             len(unique_series),
             len(to_download),
         )
-        
+
         # Download each series that needs it
         for index, series_id in enumerate(to_download, 1):
             success = self._download_single_series(series_id, index, len(to_download))
-            
+
             if success:
                 self.downloaded_count += 1
             else:
                 self.failed_count += 1
                 self.failed_series.append(series_id)
-        
+
         # Count cached series
         self.cached_count = len(self.cached_series)
-        
+
         # Log comprehensive statistics
         self._log_statistics()
 
@@ -78,19 +78,17 @@ class SeriesDownloader(DownloaderStatsMixin):
         # the stats display) would let a cache-dominated run mask a total
         # fresh-download failure. Mirror the pre-refactor success/attempted rule.
         attempted = self.downloaded_count + self.failed_count
-        download_success_rate = (
-            (self.downloaded_count / attempted * 100) if attempted else 100.0
-        )
+        download_success_rate = (self.downloaded_count / attempted * 100) if attempted else 100.0
         return download_success_rate >= 70 or attempted == 0
-    
+
     def _identify_series_to_download(self, unique_series: Set[str]) -> List[str]:
         """Identify which series need to be downloaded vs cached"""
         to_download = []
-        
+
         for series_id in unique_series:
             if not series_id:
                 continue
-                
+
             # Check cache
             cached_details = self.cache_manager.load_series_details(series_id)
             if cached_details is None:
@@ -98,9 +96,9 @@ class SeriesDownloader(DownloaderStatsMixin):
             else:
                 self.cached_series.add(series_id)
                 logging.debug("Found cached details for: %s", series_id)
-                
+
         return to_download
-    
+
     def _download_single_series(self, series_id: str, index: int, total: int) -> bool:
         """Download details for a single series"""
         logging.info(
@@ -109,22 +107,20 @@ class SeriesDownloader(DownloaderStatsMixin):
             index,
             total,
         )
-        
+
         # Prepare POST data
         data = f"programSeriesID={series_id}".encode("utf-8")
-        
+
         logging.debug("  URL: %s?programSeriesID=%s", self.base_url, series_id)
-        
+
         # Download using urllib method (works better for POST requests)
-        content = self.http_engine.download_with_retry_urllib(
-            self.base_url, data=data, timeout=6
-        )
-        
+        content = self.http_engine.download_with_retry_urllib(self.base_url, data=data, timeout=6)
+
         if content:
             try:
                 # Validate JSON
                 json.loads(content)
-                
+
                 # Save to cache
                 if self.cache_manager.save_series_details(series_id, content):
                     logging.info(
@@ -136,52 +132,55 @@ class SeriesDownloader(DownloaderStatsMixin):
                 else:
                     logging.warning("  Error saving details for: %s", series_id)
                     return False
-                    
+
             except json.JSONDecodeError:
                 logging.warning("  Invalid JSON received for: %s", series_id)
                 return False
         else:
             logging.warning("  Failed to download details for: %s", series_id)
             return False
-    
+
     def get_cached_series_details(self, series_id: str) -> Optional[Dict]:
         """Get cached series details by ID"""
         return self.cache_manager.load_series_details(series_id)
-    
+
     def _log_statistics(self):
         """Log comprehensive download statistics"""
         success_rate = self._calculate_success_rate()
-        
+
         logging.info("Extended details processing completed:")
         logging.info("  Downloads attempted: %d", self.downloaded_count)
         logging.info("  Successful downloads: %d", self.downloaded_count)
         logging.info("  Unique series from cache: %d", self.cached_count)
         logging.info("  Failed downloads: %d", self.failed_count)
-        
+
         if self.downloaded_count > 0:
             logging.info("  Download success rate: %.1f%%", success_rate)
-            
+
         # Cache efficiency calculation
         total_series = self.cached_count + self.downloaded_count
         if total_series > 0:
-            cache_efficiency = (self.cached_count / total_series * 100)
+            cache_efficiency = self.cached_count / total_series * 100
             logging.info("  Cache efficiency: %.1f%% reused", cache_efficiency)
-            
+
             if cache_efficiency > 70:
                 logging.info("  Excellent cache performance - most series were reused!")
             elif cache_efficiency > 30:
                 logging.info("  Good cache performance - significant bandwidth saved")
             else:
                 logging.info("  Low cache efficiency - mostly new content")
-        
+
         # Log some failed series for debugging
         if self.failed_series:
             logging.info(
                 "  Failed series (first 10): %s",
                 ", ".join(self.failed_series[:10]),
             )
-            
+
         # Log HTTP engine statistics
         http_stats = self.http_engine.get_statistics()
-        logging.debug("  HTTP requests: %d total, %d WAF blocks during series download", 
-                     http_stats["total_requests"], http_stats["waf_blocks"])
+        logging.debug(
+            "  HTTP requests: %d total, %d WAF blocks during series download",
+            http_stats["total_requests"],
+            http_stats["waf_blocks"],
+        )

--- a/gracenote2epg/geocoding.py
+++ b/gracenote2epg/geocoding.py
@@ -13,7 +13,6 @@ derives local stations from the postalCode that is sent directly).
 
 import csv
 import gzip
-import io
 import logging
 import sys
 from pathlib import Path
@@ -73,7 +72,9 @@ class Geocoder:
         else:
             logging.debug(message)
 
-    def resolve_location(self, postal_code: str, country: str) -> Tuple[Optional[str], Optional[str]]:
+    def resolve_location(
+        self, postal_code: str, country: str
+    ) -> Tuple[Optional[str], Optional[str]]:
         """
         Resolve postal code to city and province/state.
         For Canadian postal codes: tries the full code first, then the first 3
@@ -141,7 +142,9 @@ class Geocoder:
             city = self._extract_optimal_city_name(result, country)
 
             city = city.strip() if (city and city.strip()) else None
-            province_code = province_code.strip() if (province_code and province_code.strip()) else None
+            province_code = (
+                province_code.strip() if (province_code and province_code.strip()) else None
+            )
 
             if city and province_code:
                 self._debug("Resolved %s -> %s, %s", clean_postal, city, province_code)
@@ -158,8 +161,8 @@ class Geocoder:
         """Check if debug mode is enabled (console or logging)"""
         # Check if we have console debug (--show-lineup + --debug)
         args = sys.argv
-        has_show_lineup = any('--show-lineup' in arg for arg in args)
-        has_debug = any('--debug' in arg for arg in args)
+        has_show_lineup = any("--show-lineup" in arg for arg in args)
+        has_debug = any("--debug" in arg for arg in args)
         console_debug = has_show_lineup and has_debug
 
         # Check if logging debug is enabled
@@ -173,25 +176,26 @@ class Geocoder:
         Canada: community_name -> county_name -> place_name (cleaned)
         USA: place_name -> county_name
         """
+
         def get_field(field_name):
             value = result.get(field_name)
-            return value if value and str(value).lower() not in ['nan', 'none', ''] else None
+            return value if value and str(value).lower() not in ["nan", "none", ""] else None
 
         if country == "CAN":
             # Canada: Try community_name first (most generic)
-            city = get_field('community_name')
+            city = get_field("community_name")
             if city:
                 self._debug("Using community_name: '%s'", city)
                 return city
 
             # Fallback to county_name
-            city = get_field('county_name')
+            city = get_field("county_name")
             if city:
                 self._debug("Using county_name: '%s'", city)
                 return city
 
             # Last resort: clean place_name
-            city = get_field('place_name')
+            city = get_field("place_name")
             if city:
                 cleaned_city = self._extract_generic_city_name(city)
                 self._debug("Using cleaned place_name: '%s' -> '%s'", city, cleaned_city)
@@ -199,13 +203,13 @@ class Geocoder:
 
         else:
             # USA: place_name is usually already generic
-            city = get_field('place_name')
+            city = get_field("place_name")
             if city:
                 self._debug("Using place_name: '%s'", city)
                 return city
 
             # Fallback to county_name if needed
-            city = get_field('county_name')
+            city = get_field("county_name")
             if city:
                 self._debug("Using county_name: '%s'", city)
                 return city
@@ -223,19 +227,28 @@ class Geocoder:
             return city_name
 
         # Remove parenthetical descriptions first
-        if '(' in city_name:
-            city_name = city_name.split('(')[0].strip()
+        if "(" in city_name:
+            city_name = city_name.split("(")[0].strip()
 
         # Remove common directional/area suffixes
         directional_suffixes = [
-            ' East', ' West', ' North', ' South', ' Central',
-            ' Northeast', ' Northwest', ' Southeast', ' Southwest',
-            ' Downtown', ' Uptown', ' Midtown'
+            " East",
+            " West",
+            " North",
+            " South",
+            " Central",
+            " Northeast",
+            " Northwest",
+            " Southeast",
+            " Southwest",
+            " Downtown",
+            " Uptown",
+            " Midtown",
         ]
 
         for suffix in directional_suffixes:
             if city_name.endswith(suffix):
-                city_name = city_name[:-len(suffix)].strip()
+                city_name = city_name[: -len(suffix)].strip()
                 break
 
         return city_name

--- a/gracenote2epg/logrotate/handler.py
+++ b/gracenote2epg/logrotate/handler.py
@@ -17,6 +17,7 @@ from typing import Optional, Dict, Tuple
 
 from . import periods
 
+
 class CopyTruncateTimedRotatingFileHandler(logging.handlers.BaseRotatingHandler):
     """
     Custom log rotation handler that uses copytruncate strategy.

--- a/gracenote2epg/logrotate/manager.py
+++ b/gracenote2epg/logrotate/manager.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from .handler import CopyTruncateTimedRotatingFileHandler
 
+
 class LogRotationManager:
     """Manages log rotation configuration and setup with unified retention policies."""
 

--- a/gracenote2epg/logrotate/periods.py
+++ b/gracenote2epg/logrotate/periods.py
@@ -19,9 +19,9 @@ def next_rollover_at(when: str, interval_seconds: int) -> float:
     if when == "MIDNIGHT" or when == "DAILY":
         # Next midnight
         current_time = datetime.fromtimestamp(now)
-        next_rollover = current_time.replace(
-            hour=0, minute=0, second=0, microsecond=0
-        ) + timedelta(days=1)
+        next_rollover = current_time.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(
+            days=1
+        )
         return next_rollover.timestamp()
 
     elif when == "WEEKLY":
@@ -30,9 +30,9 @@ def next_rollover_at(when: str, interval_seconds: int) -> float:
         days_until_sunday = (6 - current_time.weekday()) % 7
         if days_until_sunday == 0:  # Today is Sunday
             days_until_sunday = 7  # Next Sunday
-        next_rollover = current_time.replace(
-            hour=0, minute=0, second=0, microsecond=0
-        ) + timedelta(days=days_until_sunday)
+        next_rollover = current_time.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(
+            days=days_until_sunday
+        )
         return next_rollover.timestamp()
 
     elif when == "MONTHLY":
@@ -67,7 +67,9 @@ def get_week_start(dt: datetime) -> datetime:
     return week_start
 
 
-def get_period_info(when: str, suffix: str, entry_datetime: datetime) -> Tuple[datetime, datetime, str]:
+def get_period_info(
+    when: str, suffix: str, entry_datetime: datetime
+) -> Tuple[datetime, datetime, str]:
     """Get period start, end, and suffix for given datetime."""
     if when == "MIDNIGHT" or when == "DAILY":
         # Daily: midnight to midnight

--- a/gracenote2epg/main.py
+++ b/gracenote2epg/main.py
@@ -392,18 +392,24 @@ def main():
             # Comprehensive download statistics
             dl_stats = data_parser.get_downloader_statistics()
             logging.info("Final download statistics:")
-            logging.info("  Guide blocks: %d downloaded, %d cached, %d failed", 
-                        dl_stats["guide"]["downloaded"],
-                        dl_stats["guide"]["cached"], 
-                        dl_stats["guide"]["failed"])
-            logging.info("  Series details: %d downloaded, %d cached, %d failed",
-                        dl_stats["series"]["downloaded"],
-                        dl_stats["series"]["cached"],
-                        dl_stats["series"]["failed"])
-            logging.info("  HTTP requests: %d total, %d WAF blocks, %.2fs final delay",
-                        dl_stats["http_engine"]["total_requests"],
-                        dl_stats["http_engine"]["waf_blocks"],
-                        dl_stats["http_engine"]["current_delay"])
+            logging.info(
+                "  Guide blocks: %d downloaded, %d cached, %d failed",
+                dl_stats["guide"]["downloaded"],
+                dl_stats["guide"]["cached"],
+                dl_stats["guide"]["failed"],
+            )
+            logging.info(
+                "  Series details: %d downloaded, %d cached, %d failed",
+                dl_stats["series"]["downloaded"],
+                dl_stats["series"]["cached"],
+                dl_stats["series"]["failed"],
+            )
+            logging.info(
+                "  HTTP requests: %d total, %d WAF blocks, %.2fs final delay",
+                dl_stats["http_engine"]["total_requests"],
+                dl_stats["http_engine"]["waf_blocks"],
+                dl_stats["http_engine"]["current_delay"],
+            )
 
             # Log final cache and retention policy status for transparency
             if retention_config.get("enabled", False):

--- a/gracenote2epg/parser/__init__.py
+++ b/gracenote2epg/parser/__init__.py
@@ -10,7 +10,7 @@ from .guide import GuideParser
 from .series import SeriesParser
 
 __all__ = [
-    "DataParser",      # Main orchestrator
-    "GuideParser",     # Pure guide parsing
-    "SeriesParser",    # Pure series parsing
+    "DataParser",  # Main orchestrator
+    "GuideParser",  # Pure guide parsing
+    "SeriesParser",  # Pure series parsing
 ]

--- a/gracenote2epg/parser/base.py
+++ b/gracenote2epg/parser/base.py
@@ -2,12 +2,12 @@
 Core orchestrator for downloading and parsing
 
 The DataParser now acts as a pure orchestrator that coordinates between:
-- Downloaders (handle HTTP and caching logic)  
+- Downloaders (handle HTTP and caching logic)
 - Parsers (handle pure data parsing logic)
 """
 
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from ..downloader import OptimizedDownloader, GuideDownloader, SeriesDownloader
 from .guide import GuideParser
@@ -16,141 +16,141 @@ from .series import SeriesParser
 
 class DataParser:
     """Main orchestrator - coordinates downloading and parsing with separated concerns"""
-    
+
     def __init__(self, cache_manager, tvh_client=None):
         self.cache_manager = cache_manager
         self.tvh_client = tvh_client
-        
+
         # Initialize HTTP engine (shared by all downloaders)
         self.http_engine = OptimizedDownloader(base_delay=0.8, min_delay=0.4)
-        
+
         # Initialize specialized downloaders
         self.guide_downloader = GuideDownloader(self.http_engine, cache_manager)
         self.series_downloader = SeriesDownloader(self.http_engine, cache_manager)
-        
+
         # Initialize pure parsers (no download logic)
         self.guide_parser = GuideParser(tvh_client)
         self.series_parser = SeriesParser()
-        
+
         # Parsed data
         self.schedule: Dict = {}
-        
-    def download_and_parse_guide(self, grid_time_start: float, day_hours: int,
-                                 config_manager, refresh_hours: int = 48) -> bool:
+
+    def download_and_parse_guide(
+        self, grid_time_start: float, day_hours: int, config_manager, refresh_hours: int = 48
+    ) -> bool:
         """
         Download and parse TV guide data with separated download/parse logic
-        
+
         Args:
             grid_time_start: Start time for guide
             day_hours: Number of 3-hour blocks
             config_manager: Configuration manager
             refresh_hours: Hours to refresh
-            
+
         Returns:
             bool: True if successful
         """
         # Get lineup configuration
         lineup_config = config_manager.get_lineup_config()
-        
+
         # PHASE 1: Download guide blocks (delegated to downloader)
         download_success = self.guide_downloader.download_guide_blocks(
             grid_time_start, day_hours, lineup_config, refresh_hours
         )
-        
+
         if not download_success:
             logging.warning("Guide download had issues, continuing with available data")
-        
+
         # PHASE 2: Parse downloaded blocks (pure parsing logic)
         self._parse_guide_blocks(grid_time_start, day_hours)
-        
+
         # Store parsed schedule
         self.schedule = self.guide_parser.get_schedule()
-        
+
         return download_success
-    
+
     def download_and_parse_series_details(self) -> bool:
         """Download and parse extended series details with separated logic"""
         # Extract active series list from parsed schedule
         series_list = self.get_active_series_list()
-        
+
         if not series_list:
             logging.info("No series found for extended details download")
             return True
-        
+
         # PHASE 1: Download series details (delegated to downloader)
         download_success = self.series_downloader.download_series_details(series_list)
-        
+
         if not download_success:
             logging.warning("Extended details download had issues, using basic descriptions")
-        
+
         # PHASE 2: Apply series details to episodes (pure parsing logic)
         self._apply_series_details_to_schedule()
-        
+
         return download_success
-    
+
     def _parse_guide_blocks(self, grid_time_start: float, day_hours: int):
         """Parse all downloaded guide blocks - pure parsing logic"""
         grid_time = grid_time_start
-        
+
         for count in range(day_hours):
             # Generate filename (shared convention with the downloader)
             from ..utils import TimeUtils
+
             filename = TimeUtils.guide_block_filename(grid_time)
-            
+
             # Load and parse block (cached data)
             content = self.cache_manager.load_guide_block(filename)
             if content:
                 try:
                     logging.debug("Parsing %s", filename)
-                    
+
                     # Parse stations on first block
                     if count == 0:
                         self.guide_parser.parse_stations(content)
-                        
+
                     # Parse episodes
                     self.guide_parser.parse_episodes(content)
-                    
+
                 except Exception as e:
                     logging.warning("Parse error for %s: %s", filename, str(e))
-            
+
             grid_time += 10800  # Next 3-hour block
-    
+
     def _apply_series_details_to_schedule(self):
         """Apply downloaded series details to parsed episodes - pure parsing logic"""
         processed_series = set()
-        
+
         for station_id, station_data in self.schedule.items():
             for episode_key, episode_data in station_data.items():
                 if episode_key.startswith("ch"):
                     continue  # Skip channel metadata
-                    
+
                 series_id = episode_data.get("epseries")
                 if not series_id or series_id in processed_series:
                     continue
-                    
+
                 # Get cached series details (already downloaded)
                 series_details = self.series_downloader.get_cached_series_details(series_id)
-                
+
                 if series_details:
                     # Pure parsing - apply details to episode data
-                    self.series_parser.parse_series_details(
-                        episode_data, series_details, series_id
-                    )
+                    self.series_parser.parse_series_details(episode_data, series_details, series_id)
                     processed_series.add(series_id)
-    
+
     def get_active_series_list(self) -> List[str]:
         """Extract list of active series from current schedule"""
         active_series = set()
-        
+
         for station_id, station_data in self.schedule.items():
             for episode_key, episode_data in station_data.items():
                 if not episode_key.startswith("ch"):
                     series_id = episode_data.get("epseries")
                     if series_id:
                         active_series.add(series_id)
-                        
+
         return list(active_series)
-    
+
     def get_schedule(self) -> Dict:
         """Get the complete parsed schedule"""
         return self.schedule
@@ -163,20 +163,20 @@ class DataParser:
         __init__, so no presence guards are needed.
         """
         return {
-            'guide': self.guide_downloader.get_downloader_statistics(),
-            'series': self.series_downloader.get_downloader_statistics(),
-            'http_engine': self.http_engine.get_statistics(),
+            "guide": self.guide_downloader.get_downloader_statistics(),
+            "series": self.series_downloader.get_downloader_statistics(),
+            "http_engine": self.http_engine.get_statistics(),
         }
-    
+
     def close(self):
         """Clean shutdown of HTTP engine"""
-        if hasattr(self, 'http_engine'):
+        if hasattr(self, "http_engine"):
             self.http_engine.close()
-            
+
     def __enter__(self):
         """Context manager entry"""
         return self
-        
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Context manager exit"""
         self.close()

--- a/gracenote2epg/parser/guide.py
+++ b/gracenote2epg/parser/guide.py
@@ -14,33 +14,33 @@ from ..utils import TimeUtils
 
 class GuideParser:
     """Parses TV guide JSON data"""
-    
+
     def __init__(self, tvh_client=None):
         self.tvh_client = tvh_client
         self.schedule: Dict = {}
-        
+
     def parse_stations(self, content: bytes) -> bool:
         """Parse station information from guide JSON data"""
         try:
             ch_guide = json.loads(content)
-            
+
             for station in ch_guide.get("channels", []):
                 station_id = station.get("channelId")
-                
+
                 if self._should_process_station(station):
                     self.schedule[station_id] = {}
-                    
+
                     # Extract basic station info
                     self.schedule[station_id]["chfcc"] = station.get("callSign")
                     self.schedule[station_id]["chnam"] = station.get("affiliateName")
-                    
+
                     # Extract icon URL
                     thumbnail = station.get("thumbnail", "")
                     if thumbnail:
                         self.schedule[station_id]["chicon"] = thumbnail.split("?")[0]
                     else:
                         self.schedule[station_id]["chicon"] = ""
-                    
+
                     # Handle channel number with TVheadend integration
                     if self.tvh_client:
                         matched_channel = self.tvh_client.get_matched_channel_number(
@@ -53,41 +53,41 @@ class GuideParser:
 
                     self.schedule[station_id]["chnum"] = matched_channel
                     self.schedule[station_id]["chtvh"] = tvh_name
-                    
+
             return True
-            
+
         except Exception as e:
             logging.exception("Exception in parse_stations: %s", str(e))
             return False
-    
+
     def parse_episodes(self, content: bytes) -> str:
         """Parse episode information from guide JSON data"""
         check_tba = "Safe"
-        
+
         try:
             ch_guide = json.loads(content)
-            
+
             for station in ch_guide.get("channels", []):
                 station_id = station.get("channelId")
-                
+
                 if self._should_process_station(station):
                     episodes = station.get("events", [])
-                    
+
                     for episode in episodes:
                         episode_data = self._parse_single_episode(episode)
                         if episode_data:
                             ep_key = episode_data["epstart"]
                             self.schedule[station_id][ep_key] = episode_data
-                            
+
                             # Check for TBA content
                             if self._check_tba_content(episode_data):
                                 check_tba = "Unsafe"
-                                
+
         except Exception as e:
             logging.exception("Exception in parse_episodes: %s", str(e))
-            
+
         return check_tba
-    
+
     def _parse_single_episode(self, episode: Dict) -> Optional[Dict]:
         """Parse individual episode data from JSON"""
         # Extract and validate start time
@@ -101,14 +101,14 @@ class GuideParser:
         end_time_str = episode.get("endTime", "")
         ep_end_ts = TimeUtils.parse_gracenote_time(end_time_str)
         ep_end = str(ep_end_ts) if ep_end_ts is not None else None
-        
+
         # Get program information
         program = episode.get("program", {})
-        
+
         # Extract descriptions with fallback logic
         short_desc = program.get("shortDesc") or ""
         long_desc = program.get("longDesc") or ""
-        
+
         # Build complete episode data structure
         return {
             "epid": program.get("tmsId"),
@@ -125,9 +125,7 @@ class GuideParser:
             "epsn": program.get("season"),
             "epen": program.get("episode"),
             "epthumb": (
-                episode.get("thumbnail", "").split("?")[0]
-                if episode.get("thumbnail")
-                else ""
+                episode.get("thumbnail", "").split("?")[0] if episode.get("thumbnail") else ""
             ),
             "epoad": None,  # Will be populated by series parser
             "epstar": None,
@@ -139,7 +137,7 @@ class GuideParser:
             "epfan": None,  # Will be populated by series parser
             "epseriesdesc": None,  # Will be populated by series parser
         }
-    
+
     def _should_process_station(self, station_data: Dict) -> bool:
         """Determine if a station should be processed based on filtering rules"""
         if self.tvh_client:
@@ -150,7 +148,7 @@ class GuideParser:
                 use_channel_matching=True,
             )
         return True  # Process all stations if no TVheadend client
-    
+
     def _check_tba_content(self, episode_data: Dict) -> bool:
         """Check if episode contains TBA (To Be Announced) content"""
         if episode_data.get("epshow") and "TBA" in episode_data["epshow"]:
@@ -158,7 +156,7 @@ class GuideParser:
         if episode_data.get("eptitle") and "TBA" in episode_data["eptitle"]:
             return True
         return False
-    
+
     def get_schedule(self) -> Dict:
         """Get the complete parsed schedule"""
         return self.schedule

--- a/gracenote2epg/parser/series.py
+++ b/gracenote2epg/parser/series.py
@@ -6,45 +6,46 @@ applying enhanced metadata to episode data. Contains only parsing logic.
 """
 
 import logging
-from typing import Dict, Optional
+from typing import Dict
 
 from ..utils import TimeUtils
 
 
 class SeriesParser:
     """Parses extended series details"""
-    
-    def parse_series_details(self, episode_data: Dict, series_details: Dict, 
-                            series_id: str) -> bool:
+
+    def parse_series_details(
+        self, episode_data: Dict, series_details: Dict, series_id: str
+    ) -> bool:
         """
         Parse and apply series details to episode data
-        
+
         Args:
             episode_data: Episode data dictionary to enhance
             series_details: Series details JSON from API
             series_id: Series ID for logging
-            
+
         Returns:
             bool: True if successful
         """
         try:
             # Extract and apply extended series description
             self._apply_series_description(episode_data, series_details, series_id)
-            
+
             # Process images
             self._apply_series_images(episode_data, series_details)
-            
+
             # Handle genres with movie detection
             self._apply_series_genres(episode_data, series_details, series_id)
-            
+
             # Process cast and crew credits (movies and TV series)
             self._apply_credits(episode_data, series_details, series_id)
 
             # Process original air date from upcoming episodes
             self._apply_original_air_date(episode_data, series_details, series_id)
-            
+
             return True
-            
+
         except Exception as e:
             logging.warning(
                 "Error processing series details for %s: %s",
@@ -52,9 +53,8 @@ class SeriesParser:
                 str(e),
             )
             return False
-    
-    def _apply_series_description(self, episode_data: Dict, series_details: Dict,
-                                 series_id: str):
+
+    def _apply_series_description(self, episode_data: Dict, series_details: Dict, series_id: str):
         """Extract and apply extended series description"""
         series_desc = series_details.get("seriesDescription")
         if series_desc and str(series_desc).strip():
@@ -70,19 +70,18 @@ class SeriesParser:
         episode_data["epimage"] = series_details.get("seriesImage")
         episode_data["epfan"] = series_details.get("backgroundImage")
 
-    def _apply_series_genres(self, episode_data: Dict, series_details: Dict,
-                            series_id: str):
+    def _apply_series_genres(self, episode_data: Dict, series_details: Dict, series_id: str):
         """Parse and apply genres with movie detection"""
         ep_genres = series_details.get("seriesGenres")
-        
+
         # Special handling for movies
-        if series_id.startswith("MV"): 
+        if series_id.startswith("MV"):
             ep_genres = "Movie|" + ep_genres if ep_genres else "Movie"
-            
+
         if ep_genres:
             episode_data["epgenres"] = ep_genres.split("|")
             logging.debug("Applied genres for %s: %s", series_id, ep_genres)
-    
+
     def _apply_credits(self, episode_data: Dict, series_details: Dict, series_id: str):
         """Parse and apply cast and crew credits (movies and TV series).
 
@@ -110,9 +109,8 @@ class SeriesParser:
                 len(cast) if isinstance(cast, list) else 0,
                 len(crew) if isinstance(crew, list) else 0,
             )
-    
-    def _apply_original_air_date(self, episode_data: Dict, series_details: Dict,
-                                series_id: str):
+
+    def _apply_original_air_date(self, episode_data: Dict, series_details: Dict, series_id: str):
         """Parse original air date from upcoming episodes data"""
         ep_list = series_details.get("upcomingEpisodeTab", [])
         if not isinstance(ep_list, list):
@@ -125,7 +123,7 @@ class SeriesParser:
         for airing in ep_list:
             if not isinstance(airing, dict):
                 continue
-                
+
             if ep_id.lower() == airing.get("tmsID", "").lower():
                 # Process original air date for TV shows (not movies)
                 if not series_id.startswith("MV"):

--- a/gracenote2epg/utils.py
+++ b/gracenote2epg/utils.py
@@ -69,7 +69,9 @@ class TimeUtils:
         return start_dt, end_dt
 
     @staticmethod
-    def parse_gracenote_time(value: Optional[str], fix_missing_seconds: bool = False) -> Optional[int]:
+    def parse_gracenote_time(
+        value: Optional[str], fix_missing_seconds: bool = False
+    ) -> Optional[int]:
         """Convert a Gracenote ISO-8601 UTC timestamp (YYYY-MM-DDTHH:MM:SSZ) to
         epoch seconds, or None if it is empty/unparseable.
 

--- a/gracenote2epg/xmltv/categories.py
+++ b/gracenote2epg/xmltv/categories.py
@@ -45,7 +45,6 @@ class CategoriesMixin:
 
                 fh.write(f'\t\t<category lang="{detected_language}">{html_safe_genre}</category>\n')
 
-
     def _get_genre_list(
         self, episode_data: Dict, ep_genre: str, use_extended_details: bool = True
     ) -> List[str]:
@@ -72,7 +71,6 @@ class CategoriesMixin:
 
         return []
 
-
     def _get_primary_genre(self, ep_filter: List, ep_genres: List) -> List[str]:
         """Get primary genre mapping"""
         genres = ep_genres if ep_genres else ep_filter
@@ -95,7 +93,6 @@ class CategoriesMixin:
 
         return ["Variety show"]  # Default
 
-
     def _get_eit_genres(self, ep_filter: List, ep_genres: List) -> List[str]:
         """Get EIT-style genre mapping"""
         genre_list = []
@@ -112,4 +109,3 @@ class CategoriesMixin:
             genre_list.insert(0, "News / Current affairs")
 
         return genre_list
-

--- a/gracenote2epg/xmltv/credits.py
+++ b/gracenote2epg/xmltv/credits.py
@@ -137,4 +137,3 @@ class CreditsMixin:
                             )
 
                 fh.write("\t\t</credits>\n")
-

--- a/gracenote2epg/xmltv/descriptions.py
+++ b/gracenote2epg/xmltv/descriptions.py
@@ -88,7 +88,6 @@ class DescriptionsMixin:
             )
             return None
 
-
     def _add_enhanced_info_to_basic_desc(
         self,
         base_desc: str,
@@ -210,4 +209,3 @@ class DescriptionsMixin:
                 str(e),
             )
             return base_desc
-

--- a/gracenote2epg/xmltv/generator.py
+++ b/gracenote2epg/xmltv/generator.py
@@ -89,7 +89,6 @@ class XmltvGenerator(
             logging.exception("Exception in XMLTV generation: %s", str(e))
             return False
 
-
     def _print_header(self, fh, encoding: str):
         """Print XMLTV header"""
         logging.info("Creating xmltv.xml file...")
@@ -99,8 +98,6 @@ class XmltvGenerator(
             '<tv source-info-url="http://tvschedule.gracenote.com/" source-info-name="gracenote.com">\n'
         )
 
-
     def _print_footer(self, fh):
         """Print XMLTV footer"""
         fh.write("</tv>\n")
-

--- a/gracenote2epg/xmltv/media.py
+++ b/gracenote2epg/xmltv/media.py
@@ -29,15 +29,14 @@ class MediaMixin:
 
             # Check if it's an MPAA rating
             if rating in mpaa_ratings:
-                fh.write(f'\t\t<rating system="MPAA">\n')
+                fh.write('\t\t<rating system="MPAA">\n')
                 fh.write(f"\t\t\t<value>{rating}</value>\n")
-                fh.write(f"\t\t</rating>\n")
+                fh.write("\t\t</rating>\n")
             else:
                 # Generic rating
-                fh.write(f"\t\t<rating>\n")
+                fh.write("\t\t<rating>\n")
                 fh.write(f"\t\t\t<value>{rating}</value>\n")
-                fh.write(f"\t\t</rating>\n")
-
+                fh.write("\t\t</rating>\n")
 
     def _write_program_icons(
         self,
@@ -70,7 +69,6 @@ class MediaMixin:
                         f'\t\t<icon src="{self.ASSETS_BASE_URL}/{episode_data["epthumb"]}.jpg" />\n'
                     )
 
-
     def _write_program_images(self, fh, episode_data: Dict, use_extended_details: bool = True):
         """Write typed <image> elements (poster/backdrop/still).
 
@@ -80,10 +78,11 @@ class MediaMixin:
         consumers that only read it. poster/backdrop come from the extended
         series details; the episode still comes from the guide thumbnail.
         """
+
         def image(img_type, orient, code):
             fh.write(
                 f'\t\t<image type="{img_type}" orient="{orient}">'
-                f'{self.ASSETS_BASE_URL}/{code}.jpg</image>\n'
+                f"{self.ASSETS_BASE_URL}/{code}.jpg</image>\n"
             )
 
         if use_extended_details:
@@ -101,4 +100,3 @@ class MediaMixin:
         if isinstance(flags, (list, tuple)):
             return any(flag in ["New", "Live"] for flag in flags)
         return False
-

--- a/gracenote2epg/xmltv/programme.py
+++ b/gracenote2epg/xmltv/programme.py
@@ -314,4 +314,3 @@ class ProgrammeMixin:
 
         except Exception as e:
             logging.exception("Exception in _print_episodes: %s", str(e))
-

--- a/gracenote2epg/xmltv/stations.py
+++ b/gracenote2epg/xmltv/stations.py
@@ -81,4 +81,3 @@ class StationsMixin:
 
         except Exception as e:
             logging.exception("Exception in _print_stations: %s", str(e))
-

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -17,10 +17,14 @@ class GeocoderTests(unittest.TestCase):
         )
 
     def test_canadian_full_code(self):
-        self.assertEqual(self.g.resolve_location("J3B1M4", "CAN"), ("Saint-Jean-sur-Richelieu", "QC"))
+        self.assertEqual(
+            self.g.resolve_location("J3B1M4", "CAN"), ("Saint-Jean-sur-Richelieu", "QC")
+        )
 
     def test_canadian_code_with_space(self):
-        self.assertEqual(self.g.resolve_location("J3B 1M4", "CAN"), ("Saint-Jean-sur-Richelieu", "QC"))
+        self.assertEqual(
+            self.g.resolve_location("J3B 1M4", "CAN"), ("Saint-Jean-sur-Richelieu", "QC")
+        )
 
     def test_canadian_fsa_fallback(self):
         # Full code absent from FSA-level data -> falls back to the 3-char FSA.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -23,9 +23,7 @@ class TimezoneOffsetTests(unittest.TestCase):
 
     def test_utc_is_signed(self):
         # UTC used to emit "0000" with no sign; must now be "+0000".
-        self.assertEqual(
-            self._offset_for(timezone=0, altzone=0, daylight=0, isdst=0), "+0000"
-        )
+        self.assertEqual(self._offset_for(timezone=0, altzone=0, daylight=0, isdst=0), "+0000")
 
     def test_eastern_standard(self):
         # EST = UTC-5, no DST
@@ -82,7 +80,7 @@ class ConvHtmlTests(unittest.TestCase):
 
     def test_escapes_xml_metacharacters(self):
         self.assertEqual(
-            HtmlUtils.conv_html('<a> & "b" \'c\''),
+            HtmlUtils.conv_html("<a> & \"b\" 'c'"),
             "&lt;a&gt; &amp; &quot;b&quot; &apos;c&apos;",
         )
 

--- a/tests/test_image_source.py
+++ b/tests/test_image_source.py
@@ -36,7 +36,9 @@ class ParseTests(unittest.TestCase):
         self.assertEqual(self.sm.parse_image_sources(p), [])
 
     def test_missing_status_defaults_enabled(self):
-        p = _write(f"<settings><imagesources><source>{FANCYBITS}</source></imagesources></settings>")
+        p = _write(
+            f"<settings><imagesources><source>{FANCYBITS}</source></imagesources></settings>"
+        )
         self.assertEqual(self.sm.parse_image_sources(p), [(FANCYBITS, True)])
 
 
@@ -59,7 +61,7 @@ class RoundTripTests(unittest.TestCase):
 
     def test_block_preserved_on_rewrite(self):
         p = _write(
-            "<settings version=\"5\">"
+            '<settings version="5">'
             f'<imagesources><source status="enabled">{TVTV}</source></imagesources>'
             "</settings>"
         )

--- a/tests/test_logrotate_periods.py
+++ b/tests/test_logrotate_periods.py
@@ -27,17 +27,13 @@ class PeriodInfoTests(unittest.TestCase):
         self.assertEqual(suffix, "2026-06-14")
 
     def test_monthly_bounds_handles_december_rollover(self):
-        start, end, suffix = periods.get_period_info(
-            "MONTHLY", "%Y-%m", datetime(2026, 12, 20)
-        )
+        start, end, suffix = periods.get_period_info("MONTHLY", "%Y-%m", datetime(2026, 12, 20))
         self.assertEqual(start, datetime(2026, 12, 1, 0, 0, 0))
         self.assertEqual(end, datetime(2026, 12, 31, 23, 59, 59))
         self.assertEqual(suffix, "2026-12")
 
     def test_weekly_bounds(self):
-        start, end, _ = periods.get_period_info(
-            "WEEKLY", "%Y-W%U", datetime(2026, 6, 10)
-        )
+        start, end, _ = periods.get_period_info("WEEKLY", "%Y-W%U", datetime(2026, 6, 10))
         self.assertEqual(start, datetime(2026, 6, 7, 0, 0, 0))
         self.assertEqual(end, datetime(2026, 6, 13, 23, 59, 59))
 

--- a/tests/test_series_parser.py
+++ b/tests/test_series_parser.py
@@ -74,17 +74,13 @@ class DisplayRatingTests(unittest.TestCase):
         self.p = SeriesParser()
 
     def test_display_rating_fills_missing_guide_rating(self):
-        d = _details(
-            upcomingEpisodeTab=[{"tmsID": "EP000000010001", "displayRating": "TV-14"}]
-        )
+        d = _details(upcomingEpisodeTab=[{"tmsID": "EP000000010001", "displayRating": "TV-14"}])
         ep = {"epid": "EP000000010001"}  # no eprating from the guide
         self.p.parse_series_details(ep, d, "EP00000001")
         self.assertEqual(ep["eprating"], "TV-14")
 
     def test_guide_rating_takes_precedence(self):
-        d = _details(
-            upcomingEpisodeTab=[{"tmsID": "EP000000010001", "displayRating": "TV-14"}]
-        )
+        d = _details(upcomingEpisodeTab=[{"tmsID": "EP000000010001", "displayRating": "TV-14"}])
         ep = {"epid": "EP000000010001", "eprating": "PG"}  # guide already set it
         self.p.parse_series_details(ep, d, "EP00000001")
         self.assertEqual(ep["eprating"], "PG")

--- a/tests/test_xmltv_golden.py
+++ b/tests/test_xmltv_golden.py
@@ -49,8 +49,18 @@ def build_schedule():
                 "epcredits": [
                     {"role": "director", "name": "Jane Director", "priority": "1"},
                     # Listed out of billing order; priority should reorder them.
-                    {"role": "actor", "name": "John Lead", "characterName": "Hero", "priority": "2"},
-                    {"role": "actor", "name": "Amy Second", "characterName": "Sidekick", "priority": "1"},
+                    {
+                        "role": "actor",
+                        "name": "John Lead",
+                        "characterName": "Hero",
+                        "priority": "2",
+                    },
+                    {
+                        "role": "actor",
+                        "name": "Amy Second",
+                        "characterName": "Sidekick",
+                        "priority": "1",
+                    },
                     {"role": "voice", "name": "Sam Voice"},
                 ],
             },
@@ -114,9 +124,7 @@ class XmltvGoldenTests(unittest.TestCase):
             "golden file missing; run: python3 -m tests.test_xmltv_golden --update-golden",
         )
         expected = GOLDEN.read_text(encoding="utf-8")
-        self.assertEqual(
-            produced, expected, "XMLTV output drifted from the golden file"
-        )
+        self.assertEqual(produced, expected, "XMLTV output drifted from the golden file")
 
 
 def _update_golden():


### PR DESCRIPTION
## Summary

Validation & corrections pass: make `make format` / `make lint` green and clear
the bulk of the **mechanical** SonarCloud code smells accumulated since the
refactor (PR #6). No behaviour change — 65 unit tests pass and the golden XMLTV
is unchanged and DTD-valid.

## Done

- **f-strings (SonarCloud S3457, ×29)**: placeholder-less `f"..."` → plain
  strings (converted safely via AST, not regex).
- **Unused imports / variables (S1481)**: removed with `autoflake`.
- **Formatting**: `black --line-length 100` across the package **and** tests,
  which fixes every flake8 finding (trailing whitespace, blank lines,
  continuation indentation). `flake8` now reports **0**.
- `make format`, `make lint` and the unit tests are all green.

## Deferred (with rationale)

- **Cognitive complexity (S3776, ×24)** — large functions (`programme.py`,
  `credits.py`, `descriptions.py`, …). These need real refactors with care to
  preserve the (golden-tested) output; a dedicated PR is safer.
- **`[0-9]` → `\d` (S6353, ×19)** — minor; `\d` also matches non-ASCII digits,
  which subtly loosens the postal/ZIP validators. Worth a deliberate decision.
- **`logging.exception()` (S8572, ×12)** — would add tracebacks to handled
  error paths; a log-verbosity judgement call.
- Assorted minor smells (duplicate literals S1192, duplicate branches S1871,
  unused params S1172 — several are interface contracts, …).
- **False positive**: `pythonbugs:S2583` (`series.py` "always false") is a Sonar
  mis-model of Python 3 true division; the branch is reachable. Suggest marking
  it *won't fix* in SonarCloud.

## Note

`make all` requires `autoflake` (pip-only; not packaged on Debian and blocked by
PEP 668 system-managed pip). With it installed, the autofix step works.
