### PR TITLE
Paced download redesign (WIP, continues PR #2 rethink)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,11 @@ with no change to the generated guide.
 - **Configurable image source**: a new `<imagesources>` config block selects the
   image host (the first `enabled` source). Mirror hosts serve the same images;
   the default is `tmsimg.fancybits.co` since `www.tvtv.ca` is rate-limited.
+- **Parallel series downloads**: a bounded pool of keep-alive workers downloads
+  series details concurrently, governed by a self-regulating (AIMD) shared rate
+  limiter. Controlled by the new `dlworkers` setting (`1`=sequential, `2`-`8`
+  =fixed, `auto`=default). ~3.4× faster on the new-series delta of a refresh,
+  with no rotating User-Agents (a single one is sufficient). Config schema → 7.
 
 ### Fixed
 - **Timezone offset**: XMLTV times now always carry a standard signed `±HHMM`
@@ -42,9 +47,9 @@ with no change to the generated guide.
   Behaviour verified byte-for-byte identical against the pre-refactor output.
 - **Geographic resolution is now built in**: postal/ZIP → city/province uses a
   small bundled GeoNames dataset read with the standard library.
-- **Config schema version 6**: introduces the `<imagesources>` block. Version-5
-  configs are upgraded automatically on the next run (a backup is written and the
-  block is injected with defaults).
+- **Config schema versions 6 and 7**: v6 introduces the `<imagesources>` block,
+  v7 the `dlworkers` setting. Older configs are upgraded automatically on the
+  next run (a backup is written and the new defaults are injected).
 
 ### Removed
 - **`pgeocode` dependency** (and its transitive `pandas`/`numpy` chain), which

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ gracenote2epg auto-detects your system and uses appropriate directories:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="6">
+<settings version="7">
   <!-- Basic guide settings -->
   <setting id="zipcode">92101</setting>                        <!-- US ZIP or Canadian postal code -->
   <setting id="lineupid">auto</setting>                        <!-- Lineup configuration -->
@@ -58,6 +58,9 @@ gracenote2epg auto-detects your system and uses appropriate directories:
   <setting id="relogs">30</setting>                            <!-- Log retention: days(number) or weekly|monthly|quarterly -->
   <setting id="rexmltv">7</setting>                            <!-- XMLTV backup retention: days(number) or weekly|monthly|quarterly -->
 
+  <!-- Download performance -->
+  <setting id="dlworkers">auto</setting>                       <!-- Parallel download workers: 1=sequential, 2-8=fixed, auto=recommended -->
+
   <!-- Image source host (first 'enabled' is used) -->
   <imagesources>
     <source status="enabled">https://tmsimg.fancybits.co/assets</source>
@@ -68,9 +71,23 @@ gracenote2epg auto-detects your system and uses appropriate directories:
 </settings>
 ```
 
-> **Schema version 6**: the `<imagesources>` block was added in version 6.
-> Existing version-5 configs are upgraded automatically on the next run (a
-> backup is written and the block is injected with defaults).
+> **Schema versions 6 / 7**: v6 added the `<imagesources>` block, v7 the
+> `dlworkers` setting. Older configs are upgraded automatically on the next run
+> (a backup is written and the new defaults are injected).
+
+## Download Performance
+
+`dlworkers` controls how series details are downloaded:
+
+- `1` — sequential (one request at a time).
+- `2`–`8` — a fixed number of parallel keep-alive workers.
+- `auto` (default) — a sensible worker count with a self-regulating rate
+  governor (starts moderate, speeds up while the server is happy, backs off on
+  rate-limit/WAF signals).
+
+Parallel workers each reuse one persistent connection and share a combined-rate
+governor, so a refresh's new-series delta downloads ~3× faster without tripping
+the server. There is a single data host (no alternate source to configure).
 
 ## Image Source
 
@@ -318,7 +335,7 @@ Same format as `relogs` - controls how long to keep XMLTV backup files.
 ### Standard Home Setup
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="6">
+<settings version="7">
   <!-- Basic guide settings -->
   <setting id="zipcode">92101</setting>
   <setting id="lineupid">auto</setting>
@@ -341,7 +358,7 @@ Same format as `relogs` - controls how long to keep XMLTV backup files.
 ### Resource-Limited System
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="6">
+<settings version="7">
   <!-- Minimal resource usage -->
   <setting id="zipcode">J3B1M4</setting>
   <setting id="lineupid">auto</setting>
@@ -364,7 +381,7 @@ Same format as `relogs` - controls how long to keep XMLTV backup files.
 ### Development/Testing
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="6">
+<settings version="7">
   <!-- Testing configuration -->
   <setting id="zipcode">92101</setting>
   <setting id="lineupid">auto</setting>

--- a/docs/parallel-download-redesign.md
+++ b/docs/parallel-download-redesign.md
@@ -81,7 +81,11 @@ safety backstop for cold/full runs.
 - [x] `downloader/pacing.py` — `RateController` (AIMD) shared governor, with tests.
 - [x] Live validation: keep-alive ~2.5× per-request; single UA fine; 4 keep-alive
       workers ~3.4× and no block.
-- [ ] `PacedWorkerPool`: fixed pool of keep-alive workers sharing the governor.
-- [ ] Wire into `SeriesDownloader` / `GuideDownloader` behind a flag; compare to
-      the current sequential path on cold + warm runs.
-- [ ] Decide config surface (worker count + rate cap profile).
+- [x] `PacedWorkerPool`: fixed pool of keep-alive workers sharing the governor.
+- [x] Real Gracenote HTTP adapter (`http.py`); single data host confirmed (no
+      mirror), so no multi-source config.
+- [x] Wired into `SeriesDownloader` behind the `dlworkers` config (1=sequential,
+      2-8=fixed, `auto`=4 + self-regulating governor; default `auto`). Schema
+      bumped to **version 7**. Live end-to-end: 24 series 15.4s → 4.5s (~3.4×).
+- [ ] Optional: extend to guide blocks; stress-test a large (500+) cold run with
+      parallelism to confirm the keep-alive pattern stays under the WAF.

--- a/docs/parallel-download-redesign.md
+++ b/docs/parallel-download-redesign.md
@@ -4,70 +4,84 @@ Rethink of the parallel download manager prototyped in PR #2
 (`parallel_download` branch). **Work in progress** — started as a foundation to
 continue from; nothing here is wired into the running downloader yet.
 
-## Why PR #2 stalled (the diagnosis)
+## Why PR #2 stalled (revised after real testing)
 
 PR #2 built a sophisticated parallel system (~4000 lines): `UnifiedDownloadManager`
 → `PreciseWorkerPool` (ThreadPoolExecutor recreated on the fly) →
-`AdaptiveStrategy` (tunes the **worker count** from success rate / latency / 429s)
-→ `RateLimiter` + `WAFDetector` → `EventDrivenMonitor` (real-time, web dashboard
-on port 9989). It blocked after ~300–500 series items.
+`AdaptiveStrategy` (tunes the **worker count**) → `RateLimiter` + `WAFDetector`
+→ `EventDrivenMonitor` (web dashboard on port 9989). It blocked after ~300–500
+series items.
 
-The root cause is **structural, not a tuning bug**:
+**Measured against the live API** (see findings below), the likely culprit is the
+**connection pattern, not request volume**:
 
-- The bottleneck is a **server-side cumulative volume limit** (Gracenote sits
-  behind an AWS WAF). It blocks after a few hundred requests per session/IP,
-  regardless of how clever the client is.
-- **Concurrency reaches that ceiling *sooner*** — more workers = a higher request
-  rate = the WAF's volume threshold trips faster. Hence "you had to reduce the
-  parallelism before getting there."
-- Reactive adaptation (cut workers when 429s appear) is **too late**: by the time
-  429s show up, the burst has already tripped the WAF, and a session/IP block
-  doesn't clear by simply reducing workers.
+- Sequential downloads **never block**, even for large runs — the server tolerates
+  a steady stream fine.
+- PR #2's series path used `urllib` with a **new TLS connection per request**, run
+  **in parallel** → a *connection-churn* pattern (many simultaneous handshakes)
+  that AWS WAF flags as bot/DDoS-like. That, not the request count, most plausibly
+  tripped the block around 300–500.
+- **Keep-alive worker connections** (a few persistent, browser-like connections,
+  each reused serially) avoid that pattern.
 
-**Conclusion:** for this API the goal is **maximum *sustainable* throughput**
-(stay just under the WAF's sustained-rate ceiling indefinitely), not peak
-throughput. Optimizing concurrency optimizes the wrong axis.
+### Live findings (gracenote overviewDetails)
+
+- **Keep-alive is a big win**: first request ~0.38s (cold TLS), then ~0.13–0.15s
+  per request on the reused connection (~2.5× faster).
+- **Single User-Agent is fine** (no rotation needed): 40 sequential requests, no
+  block. Rotating the UA on one session is *less* natural than a real browser.
+- **Bounded parallelism works**: 4 keep-alive workers → ~24 req/s, ~3.4× speedup,
+  no block.
+
+**Conclusion:** keep parallelism — it is the real win, especially for frequent
+small refreshes (6–12h) where the download delta is small and far below any wall.
+Use **bounded keep-alive workers** for speed, with a shared rate governor as a
+safety backstop for cold/full runs.
 
 ## What to keep from PR #2
 
 - The clean **task/result abstractions** (`DownloadTask` / `DownloadResult` /
   `TaskMetrics`) — elegant and reusable.
-- The **WAF detection + backoff** idea — but applied to a single paced stream.
-- The **strategy profiles** idea (conservative/balanced/aggressive) — repurposed
-  as *pacing* profiles, not worker counts.
-- The **progress/monitoring** idea — drastically simplified (a callback; no web
-  dashboard).
+- **Bounded parallelism** — it is the real win (3–4× on small/frequent refreshes).
+- The **WAF detection + backoff** idea — as a shared safety governor.
+- The **strategy profiles** idea — repurposed as small profiles (worker count +
+  rate cap).
+- The **progress** idea — a simple callback; no web dashboard.
 
 ## What to drop / rethink
 
-- The worker-pool / adaptive-worker-count machinery (`worker_pool.py`,
-  `adaptive.py`, the pool-recreation in `manager.py`).
+- The **adaptive-worker-count + pool-recreation** machinery (`worker_pool.py`'s
+  ThreadPoolExecutor churn, `adaptive.py`). Use a fixed small pool of long-lived
+  keep-alive workers instead.
+- The **per-request new connection** for series (`urllib`) — replace with
+  keep-alive (likely the actual cause of the old parallel block).
+- **User-Agent rotation** — a single constant UA is fine and more natural.
 - The 659-line monitoring + port-9989 web API.
 - It predates the modular refactor; the redesign targets the current
   `gracenote2epg/downloader/` package.
 
 ## Proposed design
 
-1. **Pacing, not parallelism.** A `RateController` using **AIMD** (TCP-style):
-   additive-increase of the request *rate* on sustained success, multiplicative-
-   decrease on a 429/WAF signal. It converges to a sawtooth just under the
-   server's ceiling and stays there — the highest rate that doesn't get blocked.
-2. **Tiny, targeted concurrency.** Optional 2–3 workers **only for guide blocks**
-   (few, larger files → overlap latency with negligible volume). Series details
-   (the 300–500 problem) stay a single paced stream.
-3. **Cache is still the main lever.** After the first run, 95 %+ of series are
-   cached, so only the *new* delta downloads — pacing only needs to be good
-   enough for the cold run / large deltas. (Future: resume across runs so a
-   blocked run continues next time.)
-4. **Simple reporting:** a progress callback + a stats summary (`TaskMetrics`).
+1. **Bounded keep-alive worker pool.** A small fixed pool (default ~4), each
+   worker owning **one persistent connection** (its own `requests.Session`) and
+   pulling tasks from a shared queue — so each worker downloads its share
+   serially over a reused connection. This is the speed win for the frequent
+   small refreshes.
+2. **Shared rate governor (backstop).** A single `RateController` (AIMD) shared
+   by all workers caps the *combined* request rate and, on a 429/WAF signal,
+   backs off globally (and may shed workers). On a normal small refresh it never
+   triggers → full parallel speed; it protects cold/full runs.
+3. **Cache stays the main lever.** After the first run, 95 %+ of series are
+   cached, so only the *new* delta downloads.
+4. **Simple reporting:** a progress callback + `TaskMetrics` summary.
 
 ## Status / next steps
 
 - [x] `downloader/tasks.py` — `DownloadTask` / `DownloadResult` / `TaskMetrics`.
-- [x] `downloader/pacing.py` — `RateController` (AIMD) + WAF cooldown, with tests.
-- [ ] `PacedDownloader` that drives tasks through the controller (single stream
-      + optional small guide concurrency), reusing the existing HTTP engine /
-      WAF detection in `downloader/base.py`.
-- [ ] Wire into `SeriesDownloader` / `GuideDownloader` behind a flag; compare
-      against the current sequential path on a cold run.
-- [ ] Decide config surface (a `download` strategy profile in the config).
+- [x] `downloader/pacing.py` — `RateController` (AIMD) shared governor, with tests.
+- [x] Live validation: keep-alive ~2.5× per-request; single UA fine; 4 keep-alive
+      workers ~3.4× and no block.
+- [ ] `PacedWorkerPool`: fixed pool of keep-alive workers sharing the governor.
+- [ ] Wire into `SeriesDownloader` / `GuideDownloader` behind a flag; compare to
+      the current sequential path on cold + warm runs.
+- [ ] Decide config surface (worker count + rate cap profile).

--- a/docs/parallel-download-redesign.md
+++ b/docs/parallel-download-redesign.md
@@ -87,5 +87,16 @@ safety backstop for cold/full runs.
 - [x] Wired into `SeriesDownloader` behind the `dlworkers` config (1=sequential,
       2-8=fixed, `auto`=4 + self-regulating governor; default `auto`). Schema
       bumped to **version 7**. Live end-to-end: 24 series 15.4s → 4.5s (~3.4×).
-- [ ] Optional: extend to guide blocks; stress-test a large (500+) cold run with
-      parallelism to confirm the keep-alive pattern stays under the WAF.
+- [x] Extended to guide blocks (same `dlworkers`); grid switched to HTTPS.
+- [x] **Stress test (500 series, 4 keep-alive workers): 498 OK, 0 rate-limited,
+      no block.** The governor ramped 5→20 req/s and held at 20 through all 500.
+      Confirms the old ~300-500 block was connection churn (urllib new connection
+      per request × parallel), not request volume — keep-alive workers avoid it.
+
+### Notes / possible follow-ups
+
+- The parallel `execute()` makes a single attempt (no per-request retry); the
+  sequential path retries. On a cold run ~0.4% of series may fail transiently
+  (e.g. giant 1.5 MB responses exceeding the timeout); they are simply
+  re-attempted on the next run (not cached). Adding a light retry to `execute`
+  would close this gap if desired.

--- a/docs/parallel-download-redesign.md
+++ b/docs/parallel-download-redesign.md
@@ -1,0 +1,73 @@
+# Download pacing redesign (WIP)
+
+Rethink of the parallel download manager prototyped in PR #2
+(`parallel_download` branch). **Work in progress** — started as a foundation to
+continue from; nothing here is wired into the running downloader yet.
+
+## Why PR #2 stalled (the diagnosis)
+
+PR #2 built a sophisticated parallel system (~4000 lines): `UnifiedDownloadManager`
+→ `PreciseWorkerPool` (ThreadPoolExecutor recreated on the fly) →
+`AdaptiveStrategy` (tunes the **worker count** from success rate / latency / 429s)
+→ `RateLimiter` + `WAFDetector` → `EventDrivenMonitor` (real-time, web dashboard
+on port 9989). It blocked after ~300–500 series items.
+
+The root cause is **structural, not a tuning bug**:
+
+- The bottleneck is a **server-side cumulative volume limit** (Gracenote sits
+  behind an AWS WAF). It blocks after a few hundred requests per session/IP,
+  regardless of how clever the client is.
+- **Concurrency reaches that ceiling *sooner*** — more workers = a higher request
+  rate = the WAF's volume threshold trips faster. Hence "you had to reduce the
+  parallelism before getting there."
+- Reactive adaptation (cut workers when 429s appear) is **too late**: by the time
+  429s show up, the burst has already tripped the WAF, and a session/IP block
+  doesn't clear by simply reducing workers.
+
+**Conclusion:** for this API the goal is **maximum *sustainable* throughput**
+(stay just under the WAF's sustained-rate ceiling indefinitely), not peak
+throughput. Optimizing concurrency optimizes the wrong axis.
+
+## What to keep from PR #2
+
+- The clean **task/result abstractions** (`DownloadTask` / `DownloadResult` /
+  `TaskMetrics`) — elegant and reusable.
+- The **WAF detection + backoff** idea — but applied to a single paced stream.
+- The **strategy profiles** idea (conservative/balanced/aggressive) — repurposed
+  as *pacing* profiles, not worker counts.
+- The **progress/monitoring** idea — drastically simplified (a callback; no web
+  dashboard).
+
+## What to drop / rethink
+
+- The worker-pool / adaptive-worker-count machinery (`worker_pool.py`,
+  `adaptive.py`, the pool-recreation in `manager.py`).
+- The 659-line monitoring + port-9989 web API.
+- It predates the modular refactor; the redesign targets the current
+  `gracenote2epg/downloader/` package.
+
+## Proposed design
+
+1. **Pacing, not parallelism.** A `RateController` using **AIMD** (TCP-style):
+   additive-increase of the request *rate* on sustained success, multiplicative-
+   decrease on a 429/WAF signal. It converges to a sawtooth just under the
+   server's ceiling and stays there — the highest rate that doesn't get blocked.
+2. **Tiny, targeted concurrency.** Optional 2–3 workers **only for guide blocks**
+   (few, larger files → overlap latency with negligible volume). Series details
+   (the 300–500 problem) stay a single paced stream.
+3. **Cache is still the main lever.** After the first run, 95 %+ of series are
+   cached, so only the *new* delta downloads — pacing only needs to be good
+   enough for the cold run / large deltas. (Future: resume across runs so a
+   blocked run continues next time.)
+4. **Simple reporting:** a progress callback + a stats summary (`TaskMetrics`).
+
+## Status / next steps
+
+- [x] `downloader/tasks.py` — `DownloadTask` / `DownloadResult` / `TaskMetrics`.
+- [x] `downloader/pacing.py` — `RateController` (AIMD) + WAF cooldown, with tests.
+- [ ] `PacedDownloader` that drives tasks through the controller (single stream
+      + optional small guide concurrency), reusing the existing HTTP engine /
+      WAF detection in `downloader/base.py`.
+- [ ] Wire into `SeriesDownloader` / `GuideDownloader` behind a flag; compare
+      against the current sequential path on a cold run.
+- [ ] Decide config surface (a `download` strategy profile in the config).

--- a/gracenote2epg.xml
+++ b/gracenote2epg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="6">
+<settings version="7">
   <!-- Basic guide settings -->
   <setting id="days">7</setting>                               <!-- Guide duration (1-14 days) -->
   <setting id="zipcode">92101</setting>                        <!-- US ZIP or Canadian postal code -->
@@ -38,6 +38,9 @@
   <setting id="logrotate">true</setting>                       <!-- Log rotation: true(daily)|false|daily|weekly|monthly -->
   <setting id="relogs">30</setting>                            <!-- Log retention: days(number) or weekly|monthly|quarterly -->
   <setting id="rexmltv">7</setting>                            <!-- XMLTV backup retention: days(number) or weekly|monthly|quarterly -->
+
+  <!-- Download performance -->
+  <setting id="dlworkers">auto</setting>                       <!-- Parallel download workers: 1=sequential, 2-8=fixed, auto=recommended -->
 
   <!-- Image source host: the first 'enabled' source is used for program/cast   -->
   <!-- images. Mirrors serve the same images; switch by toggling status         -->

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev3"
+__version__ = "2.0.0-dev4"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/cache.py
+++ b/gracenote2epg/cache.py
@@ -292,6 +292,21 @@ class CacheManager:
             logging.warning("Error validating/saving %s: %s", filename, str(e))
             return False
 
+    def guide_block_status(self, grid_time: float, filename: str, refresh_hours: int = 48) -> str:
+        """Decide what a guide block needs without downloading.
+
+        Returns "cached" (up to date), "fetch" (new or refresh-due) or "missing"
+        (absent while --norefresh prevents downloading). Mirrors the decision in
+        download_guide_block_safe so the parallel path stays consistent.
+        """
+        file_exists = (self.cache_dir / filename).exists()
+        if refresh_hours == 0:
+            return "cached" if file_exists else "missing"
+        if not file_exists:
+            return "fetch"
+        force_refresh = (grid_time - time.time()) < (refresh_hours * 3600)
+        return "fetch" if force_refresh else "cached"
+
     def download_guide_block_safe(
         self, downloader, grid_time: float, filename: str, url: str, refresh_hours: int = 48
     ) -> bool:

--- a/gracenote2epg/config/base.py
+++ b/gracenote2epg/config/base.py
@@ -99,6 +99,24 @@ class ConfigManager:
         sources = getattr(self, "image_sources", [])
         return self.settings_manager.active_image_source(sources)
 
+    # Worker count used for dlworkers="auto"
+    AUTO_DOWNLOAD_WORKERS = 4
+
+    def get_download_workers(self) -> int:
+        """Parallel download workers from ``dlworkers``.
+
+        ``1`` = sequential; ``2``-``8`` = fixed; ``auto`` (default) = a sensible
+        count, with the shared rate governor self-regulating throughput. Unknown
+        values fall back to auto.
+        """
+        value = str(self.settings.get("dlworkers", "auto")).strip().lower()
+        if value == "auto":
+            return self.AUTO_DOWNLOAD_WORKERS
+        try:
+            return max(1, min(8, int(value)))
+        except (TypeError, ValueError):
+            return self.AUTO_DOWNLOAD_WORKERS
+
     def _parse_and_migrate_config(self):
         """Parse configuration file and handle migration if needed"""
         # Parse configuration file

--- a/gracenote2epg/config/settings.py
+++ b/gracenote2epg/config/settings.py
@@ -14,13 +14,14 @@ from typing import Dict, Any, List, Optional
 class SettingsManager:
     """Handles XML settings parsing and management"""
 
-    # Current config schema version. Bumped to 6 when the <imagesources> block
-    # was introduced; older files are upgraded automatically on load.
-    CONFIG_VERSION = "6"
+    # Current config schema version. Bumped to 6 for the <imagesources> block,
+    # then 7 for the dlworkers (parallel download) setting; older files are
+    # upgraded automatically on load.
+    CONFIG_VERSION = "7"
 
     # Default configuration template
     DEFAULT_CONFIG = """<?xml version="1.0" encoding="utf-8"?>
-<settings version="6">
+<settings version="7">
   <!-- Basic guide settings -->
   <setting id="zipcode">92101</setting>
   <setting id="lineupid">auto</setting>
@@ -54,6 +55,9 @@ class SettingsManager:
   <setting id="logrotate">true</setting>
   <setting id="relogs">30</setting>
   <setting id="rexmltv">7</setting>
+
+  <!-- Download performance -->
+  <setting id="dlworkers">auto</setting>
 
   <!-- Image source host (first 'enabled' is used; mirrors serve the same images) -->
   <imagesources>
@@ -99,6 +103,7 @@ class SettingsManager:
         "logrotate",
         "relogs",
         "rexmltv",
+        "dlworkers",
     ]
 
     def __init__(self):
@@ -266,6 +271,7 @@ class SettingsManager:
                     "Cache and retention policies",
                     ["redays", "refresh", "logrotate", "relogs", "rexmltv"],
                 ),
+                ("Download performance", ["dlworkers"]),
             ]
 
             written_settings = set()
@@ -342,6 +348,7 @@ class SettingsManager:
             "logrotate": "true",
             "relogs": "30",
             "rexmltv": "7",
+            "dlworkers": "auto",
         }
 
         # Decide what is missing from the ORIGINAL file (not the live, possibly

--- a/gracenote2epg/config/validation.py
+++ b/gracenote2epg/config/validation.py
@@ -46,6 +46,8 @@ class ConfigValidator:
             "logrotate": str,
             "relogs": str,
             "rexmltv": str,
+            # Download performance
+            "dlworkers": str,
         }
 
     def validate_postal_code_format(self, postal_code: str) -> Tuple[bool, str, str]:

--- a/gracenote2epg/downloader/guide.py
+++ b/gracenote2epg/downloader/guide.py
@@ -21,7 +21,7 @@ class GuideDownloader(DownloaderStatsMixin):
     def __init__(self, http_engine: OptimizedDownloader, cache_manager: CacheManager):
         self.http_engine = http_engine
         self.cache_manager = cache_manager
-        self.base_url = "http://tvlistings.gracenote.com/api/grid"
+        self.base_url = "https://tvlistings.gracenote.com/api/grid"
 
         # Statistics
         self.downloaded_count = 0
@@ -29,7 +29,12 @@ class GuideDownloader(DownloaderStatsMixin):
         self.failed_count = 0
 
     def download_guide_blocks(
-        self, grid_time_start: float, day_hours: int, lineup_config: Dict, refresh_hours: int = 48
+        self,
+        grid_time_start: float,
+        day_hours: int,
+        lineup_config: Dict,
+        refresh_hours: int = 48,
+        workers: int = 1,
     ) -> bool:
         """
         Download guide blocks with intelligent caching
@@ -39,6 +44,7 @@ class GuideDownloader(DownloaderStatsMixin):
             day_hours: Number of 3-hour blocks to download
             lineup_config: Lineup configuration from config manager
             refresh_hours: Hours to refresh from cache
+            workers: parallel download workers (1 = sequential)
 
         Returns:
             bool: True if successful (80%+ blocks available)
@@ -54,27 +60,88 @@ class GuideDownloader(DownloaderStatsMixin):
         self.cached_count = 0
         self.failed_count = 0
 
-        # Download each block
-        grid_time = grid_time_start
-        for block_num in range(day_hours):
-            success = self._download_single_block(grid_time, lineup_config, refresh_hours)
+        if workers > 1:
+            self._download_parallel(
+                grid_time_start, day_hours, lineup_config, refresh_hours, workers
+            )
+        else:
+            # Download each block sequentially
+            grid_time = grid_time_start
+            for _ in range(day_hours):
+                success = self._download_single_block(grid_time, lineup_config, refresh_hours)
 
-            if success:
-                # Determine if it was downloaded or cached
-                time_from_now = grid_time - time.time()
-                if 0 < time_from_now < (refresh_hours * 3600):
-                    self.downloaded_count += 1
+                if success:
+                    # Determine if it was downloaded or cached
+                    time_from_now = grid_time - time.time()
+                    if 0 < time_from_now < (refresh_hours * 3600):
+                        self.downloaded_count += 1
+                    else:
+                        self.cached_count += 1
                 else:
-                    self.cached_count += 1
-            else:
-                self.failed_count += 1
+                    self.failed_count += 1
 
-            grid_time += 10800  # Next 3-hour block
+                grid_time += 10800  # Next 3-hour block
 
         # Log statistics
         self._log_statistics()
 
         return self._calculate_success_rate() >= 80
+
+    def _download_parallel(
+        self,
+        grid_time_start: float,
+        day_hours: int,
+        lineup_config: Dict,
+        refresh_hours: int,
+        workers: int,
+    ) -> None:
+        """Fetch the blocks that need it concurrently (keep-alive worker pool)."""
+        from .http import make_session, execute
+        from .tasks import DownloadTask
+        from .worker_pool import PacedWorkerPool
+
+        # Decide per block: cached / fetch / missing (no network here).
+        to_fetch = []  # (filename, was_existing)
+        tasks = []
+        grid_time = grid_time_start
+        for _ in range(day_hours):
+            filename = TimeUtils.guide_block_filename(grid_time)
+            status = self.cache_manager.guide_block_status(grid_time, filename, refresh_hours)
+            if status == "cached":
+                self.cached_count += 1
+            elif status == "missing":
+                logging.warning("Block %s not in cache and --norefresh prevents download", filename)
+                self.failed_count += 1
+            else:  # fetch
+                existed = (self.cache_manager.cache_dir / filename).exists()
+                to_fetch.append((filename, existed))
+                tasks.append(
+                    DownloadTask(
+                        task_id=filename,
+                        url=self._build_gracenote_url(lineup_config, grid_time),
+                        task_type="guide_block",
+                    )
+                )
+            grid_time += 10800
+
+        if not tasks:
+            return
+
+        existed_map = dict(to_fetch)
+        pool = PacedWorkerPool(execute, workers=workers, session_factory=make_session)
+        for result in pool.run(tasks):
+            saved = False
+            if result.success and result.content:
+                saved = self.cache_manager.validate_and_save_guide_block(
+                    result.content, result.task_id
+                )
+            if saved:
+                self.downloaded_count += 1
+            elif existed_map.get(result.task_id):
+                # Refresh failed but the previous version is still on disk.
+                self.cached_count += 1
+            else:
+                self.failed_count += 1
 
     def _download_single_block(
         self, grid_time: float, lineup_config: Dict, refresh_hours: int

--- a/gracenote2epg/downloader/http.py
+++ b/gracenote2epg/downloader/http.py
@@ -1,0 +1,101 @@
+"""
+gracenote2epg.downloader.http - Gracenote HTTP adapter for the worker pool
+
+A per-worker keep-alive session factory and a single-request ``execute`` function
+the PacedWorkerPool drives. All three known scrapers (gracenote2epg, zap2epg,
+zap2it-GuideScraping) hit the same single host, so there is no alternate data
+source to configure (unlike images). Live testing showed keep-alive cuts
+per-request latency ~2.5x and a single User-Agent is sufficient.
+"""
+
+import logging
+import time
+
+import requests
+from requests.adapters import HTTPAdapter
+
+from .tasks import DownloadResult, DownloadTask
+
+# A single, stable, browser-like User-Agent (rotation proved unnecessary).
+USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0"
+
+_HEADERS = {
+    "User-Agent": USER_AGENT,
+    "Accept": "application/json, text/html, application/xhtml+xml, */*",
+    "Accept-Language": "en-US,en;q=0.9,fr;q=0.8",
+    "Accept-Encoding": "gzip, deflate",
+    "Connection": "keep-alive",
+    "Keep-Alive": "timeout=60, max=100",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+}
+
+# AWS WAF / challenge markers (same set the legacy engine watches for).
+_WAF_MARKERS = (
+    "Human Verification",
+    "captcha-container",
+    "AwsWafIntegration",
+    "Access Denied",
+    "challenge.js",
+)
+
+
+def make_session() -> requests.Session:
+    """Create a persistent keep-alive session (one reused connection)."""
+    session = requests.Session()
+    session.headers.update(_HEADERS)
+    adapter = HTTPAdapter(pool_connections=1, pool_maxsize=1, max_retries=0, pool_block=True)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def _looks_blocked(status_code: int, text: str) -> bool:
+    if status_code in (403, 429, 503):
+        return True
+    return any(marker in text for marker in _WAF_MARKERS)
+
+
+def execute(session: requests.Session, task: DownloadTask, timeout: float = 15.0) -> DownloadResult:
+    """Perform one download for *task* over the worker's persistent *session*.
+
+    POST when the task carries a body (series details), GET otherwise (guide
+    blocks). Returns a DownloadResult; ``rate_limited`` flags a 429/WAF signal so
+    the pool's shared governor can back off.
+    """
+    t0 = time.monotonic()
+    try:
+        if task.data is not None:
+            response = session.post(
+                task.url,
+                data=task.data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=timeout,
+            )
+        else:
+            response = session.get(task.url, timeout=timeout)
+        duration = time.monotonic() - t0
+
+        if _looks_blocked(response.status_code, response.text[:2000]):
+            logging.debug(
+                "Task %s rate-limited/blocked (HTTP %s)", task.task_id, response.status_code
+            )
+            return DownloadResult(
+                task.task_id,
+                success=False,
+                http_code=response.status_code,
+                duration=duration,
+                rate_limited=True,
+            )
+
+        return DownloadResult(
+            task.task_id,
+            success=True,
+            content=response.content,
+            http_code=response.status_code,
+            duration=duration,
+        )
+    except Exception as e:
+        return DownloadResult(
+            task.task_id, success=False, error=str(e), duration=time.monotonic() - t0
+        )

--- a/gracenote2epg/downloader/http.py
+++ b/gracenote2epg/downloader/http.py
@@ -45,8 +45,8 @@ def make_session() -> requests.Session:
     session = requests.Session()
     session.headers.update(_HEADERS)
     adapter = HTTPAdapter(pool_connections=1, pool_maxsize=1, max_retries=0, pool_block=True)
+    # HTTPS only — the Gracenote data API is served over TLS.
     session.mount("https://", adapter)
-    session.mount("http://", adapter)
     return session
 
 

--- a/gracenote2epg/downloader/http.py
+++ b/gracenote2epg/downloader/http.py
@@ -56,7 +56,7 @@ def _looks_blocked(status_code: int, text: str) -> bool:
     return any(marker in text for marker in _WAF_MARKERS)
 
 
-def execute(session: requests.Session, task: DownloadTask, timeout: float = 15.0) -> DownloadResult:
+def execute(session, task: DownloadTask, timeout: float = 15.0) -> DownloadResult:
     """Perform one download for *task* over the worker's persistent *session*.
 
     POST when the task carries a body (series details), GET otherwise (guide

--- a/gracenote2epg/downloader/pacing.py
+++ b/gracenote2epg/downloader/pacing.py
@@ -16,7 +16,7 @@ testable without real time.
 """
 
 import time
-from typing import Callable
+from typing import Callable, Optional
 
 
 class RateController:
@@ -48,7 +48,7 @@ class RateController:
 
         self.rate = self._clamp(initial_rate)
         self._successes = 0
-        self._last_request: float = None
+        self._last_request: Optional[float] = None
 
     def _clamp(self, rate: float) -> float:
         return max(self._min_rate, min(self._max_rate, rate))

--- a/gracenote2epg/downloader/pacing.py
+++ b/gracenote2epg/downloader/pacing.py
@@ -1,0 +1,90 @@
+"""
+gracenote2epg.downloader.pacing - adaptive request pacing (AIMD)
+
+The Gracenote API is gated by a server-side cumulative volume limit (AWS WAF):
+it blocks after a few hundred requests, and concurrency only reaches that wall
+sooner. The right objective is therefore the maximum *sustainable* request rate,
+not peak throughput.
+
+``RateController`` implements TCP-style AIMD on the request rate: additive
+increase while requests succeed, multiplicative decrease on a rate-limit / WAF
+signal. It converges to a sawtooth just below the server's ceiling and stays
+there. See docs/parallel-download-redesign.md.
+
+The clock and sleep functions are injectable so the controller is fully
+testable without real time.
+"""
+
+import time
+from typing import Callable
+
+
+class RateController:
+    """AIMD pacer converging to the highest request rate that is not blocked."""
+
+    def __init__(
+        self,
+        *,
+        initial_rate: float = 2.0,
+        min_rate: float = 0.3,
+        max_rate: float = 8.0,
+        increase_step: float = 0.2,
+        decrease_factor: float = 0.5,
+        success_threshold: int = 10,
+        waf_cooldown: float = 20.0,
+        clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ):
+        if not (0 < min_rate <= max_rate):
+            raise ValueError("require 0 < min_rate <= max_rate")
+        self._min_rate = min_rate
+        self._max_rate = max_rate
+        self._increase_step = increase_step
+        self._decrease_factor = decrease_factor
+        self._success_threshold = max(1, success_threshold)
+        self._waf_cooldown = waf_cooldown
+        self._clock = clock
+        self._sleep = sleep
+
+        self.rate = self._clamp(initial_rate)
+        self._successes = 0
+        self._last_request: float = None
+
+    def _clamp(self, rate: float) -> float:
+        return max(self._min_rate, min(self._max_rate, rate))
+
+    @property
+    def interval(self) -> float:
+        """Current minimum delay between requests, in seconds."""
+        return 1.0 / self.rate
+
+    def wait(self) -> float:
+        """Block until the next request is allowed; returns the slept duration."""
+        slept = 0.0
+        now = self._clock()
+        if self._last_request is not None:
+            gap = self.interval - (now - self._last_request)
+            if gap > 0:
+                self._sleep(gap)
+                slept = gap
+        self._last_request = self._clock()
+        return slept
+
+    def on_success(self) -> None:
+        """Additive increase: speed up after a streak of clean requests."""
+        self._successes += 1
+        if self._successes >= self._success_threshold:
+            self._successes = 0
+            self.rate = self._clamp(self.rate + self._increase_step)
+
+    def on_rate_limited(self) -> None:
+        """Multiplicative decrease: back off on a 429 / Too Many Requests."""
+        self._successes = 0
+        self.rate = self._clamp(self.rate * self._decrease_factor)
+
+    def on_waf_block(self) -> None:
+        """A hard block: back off and pause for a cooldown before resuming."""
+        self.on_rate_limited()
+        if self._waf_cooldown > 0:
+            self._sleep(self._waf_cooldown)
+            self._last_request = self._clock()

--- a/gracenote2epg/downloader/series.py
+++ b/gracenote2epg/downloader/series.py
@@ -28,12 +28,13 @@ class SeriesDownloader(DownloaderStatsMixin):
         self.failed_series: List[str] = []
         self.cached_series: Set[str] = set()
 
-    def download_series_details(self, series_list: List[str]) -> bool:
+    def download_series_details(self, series_list: List[str], workers: int = 1) -> bool:
         """
         Download extended details for series with intelligent caching
 
         Args:
             series_list: List of series IDs to download
+            workers: parallel download workers (1 = sequential)
 
         Returns:
             bool: True if 70%+ successful
@@ -52,20 +53,24 @@ class SeriesDownloader(DownloaderStatsMixin):
         to_download = self._identify_series_to_download(unique_series)
 
         logging.info(
-            "Extended details: %d unique series found, %d downloads needed",
+            "Extended details: %d unique series found, %d downloads needed (workers=%d)",
             len(unique_series),
             len(to_download),
+            workers,
         )
 
-        # Download each series that needs it
-        for index, series_id in enumerate(to_download, 1):
-            success = self._download_single_series(series_id, index, len(to_download))
+        if workers > 1 and to_download:
+            self._download_parallel(to_download, workers)
+        else:
+            # Sequential: download each series that needs it
+            for index, series_id in enumerate(to_download, 1):
+                success = self._download_single_series(series_id, index, len(to_download))
 
-            if success:
-                self.downloaded_count += 1
-            else:
-                self.failed_count += 1
-                self.failed_series.append(series_id)
+                if success:
+                    self.downloaded_count += 1
+                else:
+                    self.failed_count += 1
+                    self.failed_series.append(series_id)
 
         # Count cached series
         self.cached_count = len(self.cached_series)
@@ -80,6 +85,45 @@ class SeriesDownloader(DownloaderStatsMixin):
         attempted = self.downloaded_count + self.failed_count
         download_success_rate = (self.downloaded_count / attempted * 100) if attempted else 100.0
         return download_success_rate >= 70 or attempted == 0
+
+    def _download_parallel(self, to_download: List[str], workers: int) -> None:
+        """Download series details with a bounded keep-alive worker pool."""
+        from .http import make_session, execute
+        from .tasks import DownloadTask
+        from .worker_pool import PacedWorkerPool
+
+        total = len(to_download)
+
+        def on_progress(done: int, _total: int):
+            if done == 1 or done % max(1, total // 10) == 0 or done == total:
+                logging.info("  Extended details: %d/%d", done, total)
+
+        tasks = [
+            DownloadTask(
+                task_id=sid,
+                url=self.base_url,
+                task_type="series_details",
+                data=f"programSeriesID={sid}".encode("utf-8"),
+            )
+            for sid in to_download
+        ]
+
+        pool = PacedWorkerPool(
+            execute, workers=workers, session_factory=make_session, on_progress=on_progress
+        )
+        for result in pool.run(tasks):
+            saved = False
+            if result.success and result.content:
+                try:
+                    json.loads(result.content)  # validate JSON
+                    saved = self.cache_manager.save_series_details(result.task_id, result.content)
+                except json.JSONDecodeError:
+                    logging.warning("  Invalid JSON received for: %s", result.task_id)
+            if saved:
+                self.downloaded_count += 1
+            else:
+                self.failed_count += 1
+                self.failed_series.append(result.task_id)
 
     def _identify_series_to_download(self, unique_series: Set[str]) -> List[str]:
         """Identify which series need to be downloaded vs cached"""

--- a/gracenote2epg/downloader/tasks.py
+++ b/gracenote2epg/downloader/tasks.py
@@ -1,0 +1,76 @@
+"""
+gracenote2epg.downloader.tasks - download task / result abstractions
+
+Small, reusable value objects for the paced download redesign (see
+docs/parallel-download-redesign.md). Kept independent of any execution model.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class DownloadTask:
+    """A single download to perform."""
+
+    task_id: str
+    url: str
+    task_type: str  # "guide_block" | "series_details"
+    data: Optional[bytes] = None  # POST body (series details)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DownloadResult:
+    """Outcome of a DownloadTask."""
+
+    task_id: str
+    success: bool
+    content: Optional[bytes] = None
+    error: Optional[str] = None
+    http_code: Optional[int] = None
+    duration: float = 0.0
+    rate_limited: bool = False
+
+    @property
+    def bytes_downloaded(self) -> int:
+        return len(self.content) if self.content else 0
+
+
+class TaskMetrics:
+    """Aggregate counters over a batch of downloads."""
+
+    def __init__(self):
+        self.downloaded = 0
+        self.cached = 0
+        self.failed = 0
+        self.rate_limited = 0
+        self.total_bytes = 0
+        self.total_duration = 0.0
+
+    def record(self, result: DownloadResult) -> None:
+        if result.success:
+            self.downloaded += 1
+            self.total_bytes += result.bytes_downloaded
+            self.total_duration += result.duration
+        else:
+            self.failed += 1
+        if result.rate_limited:
+            self.rate_limited += 1
+
+    def record_cached(self) -> None:
+        self.cached += 1
+
+    @property
+    def attempted(self) -> int:
+        return self.downloaded + self.failed
+
+    @property
+    def success_rate(self) -> float:
+        """Success rate over *attempted* (non-cached) downloads, as a percentage."""
+        return (self.downloaded / self.attempted * 100.0) if self.attempted else 100.0
+
+    @property
+    def cache_hit_rate(self) -> float:
+        processed = self.attempted + self.cached
+        return (self.cached / processed * 100.0) if processed else 0.0

--- a/gracenote2epg/downloader/worker_pool.py
+++ b/gracenote2epg/downloader/worker_pool.py
@@ -1,0 +1,111 @@
+"""
+gracenote2epg.downloader.worker_pool - bounded keep-alive worker pool
+
+A small, fixed pool of long-lived workers, each owning ONE persistent connection
+(its own session) and pulling tasks from a shared queue, so each worker
+downloads its share serially over a reused connection. A single shared
+``RateController`` (AIMD) caps the *combined* request rate and backs off globally
+on a rate-limit / WAF signal — a safety backstop that stays out of the way on
+normal small refreshes. See docs/parallel-download-redesign.md.
+
+The session factory and the per-task execute function are injected, so the pool
+is fully testable without any network.
+"""
+
+import logging
+import queue
+import threading
+from typing import Callable, List, Optional
+
+from .pacing import RateController
+from .tasks import DownloadResult, DownloadTask
+
+# (session, task) -> DownloadResult
+ExecuteFn = Callable[[object, DownloadTask], DownloadResult]
+ProgressFn = Callable[[int, int], None]
+
+
+class PacedWorkerPool:
+    """Run download tasks across a fixed pool of keep-alive workers."""
+
+    def __init__(
+        self,
+        execute: ExecuteFn,
+        *,
+        workers: int = 4,
+        session_factory: Optional[Callable[[], object]] = None,
+        governor: Optional[RateController] = None,
+        on_progress: Optional[ProgressFn] = None,
+    ):
+        self._execute = execute
+        self._workers = max(1, workers)
+        self._session_factory = session_factory or (lambda: None)
+        # Default governor stays high so it does not throttle normal operation;
+        # it only clamps down (AIMD) when the server pushes back.
+        self._governor = governor or RateController(initial_rate=20.0, max_rate=30.0, min_rate=0.5)
+        self._on_progress = on_progress
+        self._gov_lock = threading.Lock()
+
+    @property
+    def governor(self) -> RateController:
+        return self._governor
+
+    def run(self, tasks: List[DownloadTask]) -> List[DownloadResult]:
+        """Execute *tasks*; returns their results (order not guaranteed)."""
+        if not tasks:
+            return []
+
+        work: "queue.Queue[DownloadTask]" = queue.Queue()
+        for task in tasks:
+            work.put(task)
+
+        results: List[DownloadResult] = []
+        results_lock = threading.Lock()
+        total = len(tasks)
+        completed = 0
+
+        def report(result: DownloadResult) -> None:
+            nonlocal completed
+            with results_lock:
+                results.append(result)
+                completed += 1
+                progress = completed
+            if self._on_progress:
+                self._on_progress(progress, total)
+
+        def worker() -> None:
+            session = self._session_factory()
+            try:
+                while True:
+                    try:
+                        task = work.get_nowait()
+                    except queue.Empty:
+                        return
+                    # Release at the governed combined rate (serialised), then
+                    # run the request itself outside the lock so workers overlap.
+                    with self._gov_lock:
+                        self._governor.wait()
+                    try:
+                        result = self._execute(session, task)
+                    except Exception as e:  # never let one task kill a worker
+                        logging.debug("Task %s raised: %s", task.task_id, e)
+                        result = DownloadResult(task.task_id, success=False, error=str(e))
+                    with self._gov_lock:
+                        if result.rate_limited:
+                            self._governor.on_rate_limited()
+                        elif result.success:
+                            self._governor.on_success()
+                    report(result)
+                    work.task_done()
+            finally:
+                close = getattr(session, "close", None)
+                if callable(close):
+                    close()
+
+        n = min(self._workers, total)
+        threads = [threading.Thread(target=worker, daemon=True) for _ in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        return results

--- a/gracenote2epg/downloader/worker_pool.py
+++ b/gracenote2epg/downloader/worker_pool.py
@@ -40,9 +40,17 @@ class PacedWorkerPool:
         self._execute = execute
         self._workers = max(1, workers)
         self._session_factory = session_factory or (lambda: None)
-        # Default governor stays high so it does not throttle normal operation;
-        # it only clamps down (AIMD) when the server pushes back.
-        self._governor = governor or RateController(initial_rate=20.0, max_rate=30.0, min_rate=0.5)
+        # Self-regulating governor: starts moderate (safe even on a cold run of
+        # hundreds of new series), ramps up via AIMD while the server is happy,
+        # and backs off on a 429/WAF signal.
+        self._governor = governor or RateController(
+            initial_rate=5.0,
+            max_rate=20.0,
+            min_rate=0.5,
+            increase_step=0.5,
+            success_threshold=10,
+            decrease_factor=0.5,
+        )
         self._on_progress = on_progress
         self._gov_lock = threading.Lock()
 

--- a/gracenote2epg/downloader/worker_pool.py
+++ b/gracenote2epg/downloader/worker_pool.py
@@ -67,53 +67,63 @@ class PacedWorkerPool:
         for task in tasks:
             work.put(task)
 
-        results: List[DownloadResult] = []
-        results_lock = threading.Lock()
-        total = len(tasks)
-        completed = 0
-
-        def report(result: DownloadResult) -> None:
-            nonlocal completed
-            with results_lock:
-                results.append(result)
-                completed += 1
-                progress = completed
-            if self._on_progress:
-                self._on_progress(progress, total)
-
-        def worker() -> None:
-            session = self._session_factory()
-            try:
-                while True:
-                    try:
-                        task = work.get_nowait()
-                    except queue.Empty:
-                        return
-                    # Release at the governed combined rate (serialised), then
-                    # run the request itself outside the lock so workers overlap.
-                    with self._gov_lock:
-                        self._governor.wait()
-                    try:
-                        result = self._execute(session, task)
-                    except Exception as e:  # never let one task kill a worker
-                        logging.debug("Task %s raised: %s", task.task_id, e)
-                        result = DownloadResult(task.task_id, success=False, error=str(e))
-                    with self._gov_lock:
-                        if result.rate_limited:
-                            self._governor.on_rate_limited()
-                        elif result.success:
-                            self._governor.on_success()
-                    report(result)
-                    work.task_done()
-            finally:
-                close = getattr(session, "close", None)
-                if callable(close):
-                    close()
-
-        n = min(self._workers, total)
-        threads = [threading.Thread(target=worker, daemon=True) for _ in range(n)]
+        sink = _ResultSink(len(tasks), self._on_progress)
+        n = min(self._workers, len(tasks))
+        threads = [
+            threading.Thread(target=self._worker_loop, args=(work, sink), daemon=True)
+            for _ in range(n)
+        ]
         for t in threads:
             t.start()
         for t in threads:
             t.join()
-        return results
+        return sink.results
+
+    def _worker_loop(self, work: "queue.Queue[DownloadTask]", sink: "_ResultSink") -> None:
+        """One worker: own a persistent session, drain the queue."""
+        session = self._session_factory()
+        try:
+            while True:
+                try:
+                    task = work.get_nowait()
+                except queue.Empty:
+                    return
+                sink.add(self._process(session, task))
+                work.task_done()
+        finally:
+            close = getattr(session, "close", None)
+            if callable(close):
+                close()
+
+    def _process(self, session, task: DownloadTask) -> DownloadResult:
+        """Pace (governed combined rate), run one request, feed the governor."""
+        with self._gov_lock:
+            self._governor.wait()
+        try:
+            result = self._execute(session, task)
+        except Exception as e:  # never let one task kill a worker
+            logging.debug("Task %s raised: %s", task.task_id, e)
+            result = DownloadResult(task.task_id, success=False, error=str(e))
+        with self._gov_lock:
+            if result.rate_limited:
+                self._governor.on_rate_limited()
+            elif result.success:
+                self._governor.on_success()
+        return result
+
+
+class _ResultSink:
+    """Thread-safe result collector with progress reporting."""
+
+    def __init__(self, total: int, on_progress: Optional[ProgressFn]):
+        self.results: List[DownloadResult] = []
+        self._total = total
+        self._on_progress = on_progress
+        self._lock = threading.Lock()
+
+    def add(self, result: DownloadResult) -> None:
+        with self._lock:
+            self.results.append(result)
+            done = len(self.results)
+        if self._on_progress:
+            self._on_progress(done, self._total)

--- a/gracenote2epg/main.py
+++ b/gracenote2epg/main.py
@@ -353,7 +353,9 @@ def main():
 
             # Download extended details if needed
             if config_manager.needs_extended_download():
-                extended_success = data_parser.download_and_parse_series_details()
+                extended_success = data_parser.download_and_parse_series_details(
+                    workers=config_manager.get_download_workers()
+                )
                 if not extended_success:
                     logging.warning(
                         "Extended details download had issues, using basic descriptions"

--- a/gracenote2epg/parser/base.py
+++ b/gracenote2epg/parser/base.py
@@ -52,10 +52,11 @@ class DataParser:
         """
         # Get lineup configuration
         lineup_config = config_manager.get_lineup_config()
+        workers = config_manager.get_download_workers()
 
         # PHASE 1: Download guide blocks (delegated to downloader)
         download_success = self.guide_downloader.download_guide_blocks(
-            grid_time_start, day_hours, lineup_config, refresh_hours
+            grid_time_start, day_hours, lineup_config, refresh_hours, workers
         )
 
         if not download_success:

--- a/gracenote2epg/parser/base.py
+++ b/gracenote2epg/parser/base.py
@@ -69,7 +69,7 @@ class DataParser:
 
         return download_success
 
-    def download_and_parse_series_details(self) -> bool:
+    def download_and_parse_series_details(self, workers: int = 1) -> bool:
         """Download and parse extended series details with separated logic"""
         # Extract active series list from parsed schedule
         series_list = self.get_active_series_list()
@@ -79,7 +79,7 @@ class DataParser:
             return True
 
         # PHASE 1: Download series details (delegated to downloader)
-        download_success = self.series_downloader.download_series_details(series_list)
+        download_success = self.series_downloader.download_series_details(series_list, workers)
 
         if not download_success:
             logging.warning("Extended details download had issues, using basic descriptions")

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,85 @@
+"""Tests for the Gracenote HTTP adapter (execute), using a fake session."""
+
+import unittest
+
+from gracenote2epg.downloader.http import execute
+from gracenote2epg.downloader.tasks import DownloadTask
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, text="{}", content=b"{}"):
+        self.status_code = status_code
+        self.text = text
+        self.content = content
+
+
+class FakeSession:
+    def __init__(self, response=None, raises=None):
+        self._response = response or FakeResponse()
+        self._raises = raises
+        self.posted = None
+        self.got = None
+
+    def post(self, url, **kw):
+        self.posted = (url, kw)
+        if self._raises:
+            raise self._raises
+        return self._response
+
+    def get(self, url, **kw):
+        self.got = (url, kw)
+        if self._raises:
+            raise self._raises
+        return self._response
+
+
+def series_task():
+    return DownloadTask(
+        "SH1",
+        "https://h/api/program/overviewDetails",
+        "series_details",
+        data=b"programSeriesID=SH1",
+    )
+
+
+def guide_task():
+    return DownloadTask("2026010100", "https://h/api/grid?x=1", "guide_block")
+
+
+class ExecuteTests(unittest.TestCase):
+    def test_series_uses_post_with_body(self):
+        s = FakeSession(FakeResponse(200, '{"ok":1}', b'{"ok":1}'))
+        r = execute(s, series_task())
+        self.assertTrue(r.success)
+        self.assertEqual(r.content, b'{"ok":1}')
+        self.assertEqual(s.posted[0], "https://h/api/program/overviewDetails")
+        self.assertIsNone(s.got)  # not a GET
+
+    def test_guide_uses_get(self):
+        s = FakeSession(FakeResponse(200, "{}", b"{}"))
+        r = execute(s, guide_task())
+        self.assertTrue(r.success)
+        self.assertIsNotNone(s.got)
+        self.assertIsNone(s.posted)
+
+    def test_429_is_rate_limited(self):
+        r = execute(FakeSession(FakeResponse(429, "Too Many Requests")), series_task())
+        self.assertFalse(r.success)
+        self.assertTrue(r.rate_limited)
+        self.assertEqual(r.http_code, 429)
+
+    def test_waf_challenge_body_is_rate_limited(self):
+        body = "<html>... AwsWafIntegration challenge.js ...</html>"
+        r = execute(FakeSession(FakeResponse(200, body, body.encode())), series_task())
+        self.assertFalse(r.success)
+        self.assertTrue(r.rate_limited)
+
+    def test_exception_is_a_failure_not_a_crash(self):
+        r = execute(FakeSession(raises=OSError("connection reset")), series_task())
+        self.assertFalse(r.success)
+        self.assertFalse(r.rate_limited)
+        self.assertIn("connection reset", r.error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pacing.py
+++ b/tests/test_pacing.py
@@ -1,0 +1,145 @@
+"""Tests for the AIMD RateController and the download task abstractions."""
+
+import unittest
+
+from gracenote2epg.downloader.pacing import RateController
+from gracenote2epg.downloader.tasks import DownloadResult, TaskMetrics
+
+
+class FakeTime:
+    """Manually-advanced clock + sleep that advances it."""
+
+    def __init__(self):
+        self.now = 0.0
+        self.slept = []
+
+    def clock(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+class RateControllerBasicsTests(unittest.TestCase):
+    def _rc(self, **kw):
+        self.t = FakeTime()
+        return RateController(clock=self.t.clock, sleep=self.t.sleep, **kw)
+
+    def test_additive_increase_after_threshold(self):
+        rc = self._rc(initial_rate=2.0, increase_step=0.5, success_threshold=3, max_rate=10)
+        for _ in range(2):
+            rc.on_success()
+        self.assertEqual(rc.rate, 2.0)  # not yet
+        rc.on_success()  # 3rd -> increase
+        self.assertEqual(rc.rate, 2.5)
+
+    def test_multiplicative_decrease_on_rate_limit(self):
+        rc = self._rc(initial_rate=4.0, decrease_factor=0.5, min_rate=0.3)
+        rc.on_rate_limited()
+        self.assertEqual(rc.rate, 2.0)
+
+    def test_rate_is_clamped(self):
+        rc = self._rc(initial_rate=1.0, min_rate=0.5, max_rate=3.0, increase_step=5)
+        for _ in range(100):
+            rc.on_success()
+        self.assertLessEqual(rc.rate, 3.0)
+        for _ in range(100):
+            rc.on_rate_limited()
+        self.assertGreaterEqual(rc.rate, 0.5)
+
+    def test_a_429_resets_the_success_streak(self):
+        rc = self._rc(initial_rate=2.0, increase_step=0.5, success_threshold=3)
+        rc.on_success()
+        rc.on_success()
+        rc.on_rate_limited()  # resets streak (and halves)
+        rc.on_success()
+        rc.on_success()
+        self.assertEqual(rc.rate, 1.0)  # only the 429's halving applied, no increase yet
+
+
+class RateControllerPacingTests(unittest.TestCase):
+    def test_wait_respects_the_interval(self):
+        t = FakeTime()
+        rc = RateController(initial_rate=2.0, clock=t.clock, sleep=t.sleep)  # interval 0.5s
+        rc.wait()  # first call: nothing to wait
+        self.assertEqual(t.slept, [])
+        # no real time passed -> next wait must sleep a full interval
+        rc.wait()
+        self.assertAlmostEqual(t.slept[-1], 0.5, places=6)
+
+    def test_wait_accounts_for_elapsed_time(self):
+        t = FakeTime()
+        rc = RateController(initial_rate=2.0, clock=t.clock, sleep=t.sleep)  # interval 0.5
+        rc.wait()
+        t.now += 0.2  # 0.2s already elapsed
+        rc.wait()
+        self.assertAlmostEqual(t.slept[-1], 0.3, places=6)  # only the remainder
+
+    def test_waf_block_backs_off_and_cools_down(self):
+        t = FakeTime()
+        rc = RateController(
+            initial_rate=4.0,
+            decrease_factor=0.5,
+            waf_cooldown=15.0,
+            clock=t.clock,
+            sleep=t.sleep,
+        )
+        rc.on_waf_block()
+        self.assertEqual(rc.rate, 2.0)  # backed off
+        self.assertIn(15.0, t.slept)  # cooled down
+
+
+class RateControllerConvergenceTests(unittest.TestCase):
+    def test_converges_to_a_band_just_under_the_server_ceiling(self):
+        """Simulate a server that blocks above a hidden sustainable ceiling."""
+        t = FakeTime()
+        ceiling = 5.0
+        rc = RateController(
+            initial_rate=1.0,
+            min_rate=0.3,
+            max_rate=12.0,
+            increase_step=0.3,
+            decrease_factor=0.5,
+            success_threshold=5,
+            clock=t.clock,
+            sleep=t.sleep,
+        )
+        observed = []
+        for _ in range(2000):
+            rc.wait()
+            t.now += 0.0001  # tiny processing time
+            if rc.rate > ceiling:
+                rc.on_rate_limited()
+            else:
+                rc.on_success()
+            observed.append(rc.rate)
+
+        tail = observed[-300:]
+        # Never runs away above the ceiling by more than one increase step.
+        self.assertLessEqual(max(tail), ceiling + 0.3 + 1e-6)
+        # Keeps probing near the ceiling (doesn't collapse to the floor).
+        self.assertGreaterEqual(max(tail), ceiling * 0.8)
+        # Stays well above the minimum on average.
+        self.assertGreater(sum(tail) / len(tail), ceiling * 0.45)
+
+
+class TaskAbstractionTests(unittest.TestCase):
+    def test_bytes_downloaded(self):
+        self.assertEqual(DownloadResult("a", True, content=b"hello").bytes_downloaded, 5)
+        self.assertEqual(DownloadResult("a", False).bytes_downloaded, 0)
+
+    def test_metrics_success_and_cache_rates(self):
+        m = TaskMetrics()
+        m.record(DownloadResult("1", True, content=b"x" * 100, duration=1.0))
+        m.record(DownloadResult("2", False, rate_limited=True))
+        m.record_cached()
+        m.record_cached()
+        self.assertEqual(m.attempted, 2)
+        self.assertEqual(m.success_rate, 50.0)
+        self.assertEqual(m.rate_limited, 1)
+        self.assertAlmostEqual(m.cache_hit_rate, 50.0)  # 2 cached of 4 processed
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_worker_pool.py
+++ b/tests/test_worker_pool.py
@@ -1,0 +1,135 @@
+"""Tests for the PacedWorkerPool (keep-alive workers + shared governor)."""
+
+import threading
+import unittest
+
+from gracenote2epg.downloader.pacing import RateController
+from gracenote2epg.downloader.worker_pool import PacedWorkerPool
+from gracenote2epg.downloader.tasks import DownloadResult, DownloadTask
+
+
+def instant_governor(**kw):
+    """A RateController whose wait() never actually sleeps (test-fast)."""
+    return RateController(clock=lambda: 0.0, sleep=lambda s: None, **kw)
+
+
+def tasks(n):
+    return [DownloadTask(task_id=str(i), url="u", task_type="series_details") for i in range(n)]
+
+
+class FakeSession:
+    _counter = 0
+    _lock = threading.Lock()
+
+    def __init__(self):
+        with FakeSession._lock:
+            FakeSession._counter += 1
+            self.id = FakeSession._counter
+        self.handled = 0
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class CompletenessTests(unittest.TestCase):
+    def test_all_tasks_get_a_result(self):
+        def execute(session, task):
+            return DownloadResult(task.task_id, success=True, content=b"x")
+
+        pool = PacedWorkerPool(execute, workers=4, governor=instant_governor())
+        results = pool.run(tasks(50))
+        self.assertEqual(len(results), 50)
+        self.assertEqual({r.task_id for r in results}, {str(i) for i in range(50)})
+        self.assertTrue(all(r.success for r in results))
+
+    def test_empty_tasks(self):
+        pool = PacedWorkerPool(lambda s, t: None, governor=instant_governor())
+        self.assertEqual(pool.run([]), [])
+
+    def test_single_worker(self):
+        pool = PacedWorkerPool(
+            lambda s, t: DownloadResult(t.task_id, True), workers=1, governor=instant_governor()
+        )
+        self.assertEqual(len(pool.run(tasks(10))), 10)
+
+    def test_a_failing_task_does_not_kill_the_worker(self):
+        def execute(session, task):
+            if task.task_id == "3":
+                raise RuntimeError("boom")
+            return DownloadResult(task.task_id, success=True)
+
+        results = PacedWorkerPool(execute, workers=2, governor=instant_governor()).run(tasks(10))
+        self.assertEqual(len(results), 10)  # all accounted for
+        self.assertFalse(next(r for r in results if r.task_id == "3").success)
+
+
+class KeepAliveTests(unittest.TestCase):
+    def test_workers_reuse_one_session_each(self):
+        FakeSession._counter = 0
+        created = []
+        clock = threading.Lock()
+
+        def factory():
+            s = FakeSession()
+            with clock:
+                created.append(s)
+            return s
+
+        def execute(session, task):
+            session.handled += 1
+            return DownloadResult(task.task_id, success=True)
+
+        pool = PacedWorkerPool(
+            execute, workers=4, session_factory=factory, governor=instant_governor()
+        )
+        pool.run(tasks(60))
+        # At most one session per worker (persistent, reused), not one per task.
+        self.assertLessEqual(len(created), 4)
+        self.assertEqual(sum(s.handled for s in created), 60)
+        self.assertTrue(all(s.closed for s in created))  # sessions closed at the end
+
+
+class ProgressTests(unittest.TestCase):
+    def test_progress_reaches_total(self):
+        seen = []
+        lock = threading.Lock()
+
+        def on_progress(done, total):
+            with lock:
+                seen.append((done, total))
+
+        pool = PacedWorkerPool(
+            lambda s, t: DownloadResult(t.task_id, True),
+            workers=3,
+            governor=instant_governor(),
+            on_progress=on_progress,
+        )
+        pool.run(tasks(20))
+        self.assertEqual(len(seen), 20)
+        self.assertEqual(max(d for d, _ in seen), 20)
+        self.assertTrue(all(total == 20 for _, total in seen))
+
+
+class GovernorBackstopTests(unittest.TestCase):
+    def test_governor_backs_off_on_rate_limits_but_pool_completes(self):
+        # Fake server: rate-limits the first few requests, then succeeds.
+        state = {"n": 0}
+        lock = threading.Lock()
+
+        def execute(session, task):
+            with lock:
+                state["n"] += 1
+                limited = state["n"] <= 5
+            return DownloadResult(task.task_id, success=not limited, rate_limited=limited)
+
+        gov = instant_governor(initial_rate=8.0, decrease_factor=0.5, min_rate=0.5)
+        pool = PacedWorkerPool(execute, workers=4, governor=gov)
+        results = pool.run(tasks(40))
+        self.assertEqual(len(results), 40)  # all processed, no deadlock
+        # The governor reacted to the early 429s (rate pulled below the start).
+        self.assertLess(gov.rate, 8.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Reworks the parallel download manager prototyped in PR #2 into a small, tested
design that keeps parallelism (the real speed win) while staying friendly to the
Gracenote API. Controlled by a new `dlworkers` config setting (schema **v7**).

## Why PR #2 stalled — and the fix

PR #2 (~4000 lines) blocked after ~300–500 series. **Live testing showed the
cause was the connection pattern, not request volume**: it opened a new TLS
connection per request (`urllib`) in parallel — a churn pattern AWS WAF flags as
bot-like. Sequential downloads never block.

The fix: a small pool of **keep-alive workers** (each reuses one connection),
sharing a self-regulating **AIMD rate governor** as a safety backstop.

### Live measurements

- Keep-alive: ~2.5× lower per-request latency (0.38s cold → ~0.14s reused).
- A single User-Agent is sufficient (no rotation).
- 24 new series: 15.4s sequential → 4.5s with 4 workers (~3.4×).
- **Stress test — 500 series, 4 workers: 498 OK, 0 rate-limited, no block**;
  governor ramped 5→20 req/s and held. Confirms keep-alive avoids the old wall.

## What's included

- `downloader/pacing.py` — `RateController` (AIMD), tested.
- `downloader/worker_pool.py` — `PacedWorkerPool` (keep-alive workers + shared
  governor), tested without network.
- `downloader/http.py` — Gracenote session/execute adapter (HTTPS only).
- `downloader/tasks.py` — `DownloadTask`/`DownloadResult`/`TaskMetrics`.
- Wired into **series and guide** downloads behind `dlworkers`
  (`1`=sequential, `2`-`8`=fixed, `auto`=default). Grid switched to HTTPS.
- Config schema **v7** (auto-upgrades older configs); docs updated.

There is a single data host (`tvlistings.gracenote.com`); a probe of
alternatives found none, so no multi-source config (the pool is source-agnostic
if one ever appears).
