### PR TITLE
Parallel downloads: retry/requeue + accurate request stats

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,7 +32,9 @@ with no change to the generated guide.
   shared rate limiter. Controlled by the new `dlworkers` setting (`1`
   =sequential, `2`-`8`=fixed, `auto`=default). ~3.4× faster on the new-series
   delta of a refresh, with no rotating User-Agents (a single one is
-  sufficient). Config schema → 7.
+  sufficient). Config schema → 7. Failed downloads are re-queued (guide retried
+  harder than non-critical series details), and the final stats report the
+  pool's request counts accurately.
 
 ### Fixed
 - **Series details on every airing**: extended details (series box-art `<icon>`,

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev5"
+__version__ = "2.0.0-dev6"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/downloader/base.py
+++ b/gracenote2epg/downloader/base.py
@@ -363,11 +363,17 @@ class DownloaderStatsMixin:
     downloaded_count: int = 0
     cached_count: int = 0
     failed_count: int = 0
+    # Network request counters from the parallel pool (0 in sequential mode,
+    # where the shared OptimizedDownloader engine reports its own totals).
+    http_requests: int = 0
+    rate_limited: int = 0
 
     def _reset_counters(self):
         self.downloaded_count = 0
         self.cached_count = 0
         self.failed_count = 0
+        self.http_requests = 0
+        self.rate_limited = 0
 
     def _calculate_success_rate(self) -> float:
         """Overall success rate (downloads + cache hits) for the stats display."""
@@ -388,4 +394,6 @@ class DownloaderStatsMixin:
             "cache_efficiency": (
                 (self.cached_count / cached_or_downloaded * 100) if cached_or_downloaded > 0 else 0
             ),
+            "http_requests": self.http_requests,
+            "rate_limited": self.rate_limited,
         }

--- a/gracenote2epg/downloader/guide.py
+++ b/gracenote2epg/downloader/guide.py
@@ -129,7 +129,8 @@ class GuideDownloader(DownloaderStatsMixin):
 
         existed_map = dict(to_fetch)
         pool = PacedWorkerPool(execute, workers=workers, session_factory=make_session)
-        for result in pool.run(tasks):
+        # Guide blocks are important: retry failed ones (re-queued at the end).
+        for result in pool.run(tasks, max_attempts=3):
             saved = False
             if result.success and result.content:
                 saved = self.cache_manager.validate_and_save_guide_block(
@@ -142,6 +143,9 @@ class GuideDownloader(DownloaderStatsMixin):
                 self.cached_count += 1
             else:
                 self.failed_count += 1
+
+        self.http_requests = pool.requests
+        self.rate_limited = pool.rate_limited
 
     def _download_single_block(
         self, grid_time: float, lineup_config: Dict, refresh_hours: int

--- a/gracenote2epg/downloader/series.py
+++ b/gracenote2epg/downloader/series.py
@@ -111,7 +111,9 @@ class SeriesDownloader(DownloaderStatsMixin):
         pool = PacedWorkerPool(
             execute, workers=workers, session_factory=make_session, on_progress=on_progress
         )
-        for result in pool.run(tasks):
+        # Series details are non-critical: one best-effort retry (re-queued at
+        # the end), and anything still missing is simply re-fetched next run.
+        for result in pool.run(tasks, max_attempts=2):
             saved = False
             if result.success and result.content:
                 try:
@@ -124,6 +126,9 @@ class SeriesDownloader(DownloaderStatsMixin):
             else:
                 self.failed_count += 1
                 self.failed_series.append(result.task_id)
+
+        self.http_requests = pool.requests
+        self.rate_limited = pool.rate_limited
 
     def _identify_series_to_download(self, unique_series: Set[str]) -> List[str]:
         """Identify which series need to be downloaded vs cached"""

--- a/gracenote2epg/downloader/worker_pool.py
+++ b/gracenote2epg/downloader/worker_pool.py
@@ -53,24 +53,37 @@ class PacedWorkerPool:
         )
         self._on_progress = on_progress
         self._gov_lock = threading.Lock()
+        self._stats_lock = threading.Lock()
+        # Aggregate request stats (one entry per attempt), for reporting.
+        self.requests = 0
+        self.rate_limited = 0
 
     @property
     def governor(self) -> RateController:
         return self._governor
 
-    def run(self, tasks: List[DownloadTask]) -> List[DownloadResult]:
-        """Execute *tasks*; returns their results (order not guaranteed)."""
+    def run(self, tasks: List[DownloadTask], max_attempts: int = 1) -> List[DownloadResult]:
+        """Execute *tasks*; returns their final results (order not guaranteed).
+
+        Failed tasks (including rate-limited ones) are re-queued at the **end**
+        and retried up to ``max_attempts`` total, so a transient/blocked request
+        is given another chance after the rest of the batch (and after the
+        governor has backed off).
+        """
         if not tasks:
             return []
+        self.requests = 0
+        self.rate_limited = 0
 
-        work: "queue.Queue[DownloadTask]" = queue.Queue()
+        # Queue carries (task, attempt_number).
+        work: "queue.Queue" = queue.Queue()
         for task in tasks:
-            work.put(task)
+            work.put((task, 1))
 
         sink = _ResultSink(len(tasks), self._on_progress)
         n = min(self._workers, len(tasks))
         threads = [
-            threading.Thread(target=self._worker_loop, args=(work, sink), daemon=True)
+            threading.Thread(target=self._worker_loop, args=(work, sink, max_attempts), daemon=True)
             for _ in range(n)
         ]
         for t in threads:
@@ -79,17 +92,23 @@ class PacedWorkerPool:
             t.join()
         return sink.results
 
-    def _worker_loop(self, work: "queue.Queue[DownloadTask]", sink: "_ResultSink") -> None:
-        """One worker: own a persistent session, drain the queue."""
+    def _worker_loop(self, work: "queue.Queue", sink: "_ResultSink", max_attempts: int) -> None:
+        """One worker: own a persistent session, drain the queue (with requeue)."""
         session = self._session_factory()
         try:
-            while True:
+            # Terminate on finalised count, not queue-empty, because failures get
+            # re-queued (a worker could otherwise exit while a requeue is pending).
+            while not sink.complete:
                 try:
-                    task = work.get_nowait()
+                    task, attempt = work.get(timeout=0.1)
                 except queue.Empty:
-                    return
-                sink.add(self._process(session, task))
-                work.task_done()
+                    continue
+                result = self._process(session, task)
+                if not result.success and attempt < max_attempts:
+                    logging.debug("Requeue %s (attempt %d/%d)", task.task_id, attempt, max_attempts)
+                    work.put((task, attempt + 1))
+                else:
+                    sink.add(result)
         finally:
             close = getattr(session, "close", None)
             if callable(close):
@@ -109,6 +128,10 @@ class PacedWorkerPool:
                 self._governor.on_rate_limited()
             elif result.success:
                 self._governor.on_success()
+        with self._stats_lock:
+            self.requests += 1
+            if result.rate_limited:
+                self.rate_limited += 1
         return result
 
 
@@ -127,3 +150,8 @@ class _ResultSink:
             done = len(self.results)
         if self._on_progress:
             self._on_progress(done, self._total)
+
+    @property
+    def complete(self) -> bool:
+        with self._lock:
+            return len(self.results) >= self._total

--- a/gracenote2epg/main.py
+++ b/gracenote2epg/main.py
@@ -406,11 +406,22 @@ def main():
                 dl_stats["series"]["cached"],
                 dl_stats["series"]["failed"],
             )
+            # Combine the sequential HTTP engine and the parallel worker pools so
+            # the totals are accurate in either download mode.
+            total_requests = (
+                dl_stats["http_engine"]["total_requests"]
+                + dl_stats["guide"].get("http_requests", 0)
+                + dl_stats["series"].get("http_requests", 0)
+            )
+            blocked = (
+                dl_stats["http_engine"]["waf_blocks"]
+                + dl_stats["guide"].get("rate_limited", 0)
+                + dl_stats["series"].get("rate_limited", 0)
+            )
             logging.info(
-                "  HTTP requests: %d total, %d WAF blocks, %.2fs final delay",
-                dl_stats["http_engine"]["total_requests"],
-                dl_stats["http_engine"]["waf_blocks"],
-                dl_stats["http_engine"]["current_delay"],
+                "  Network requests: %d total, %d rate-limited/blocked",
+                total_requests,
+                blocked,
             )
 
             # Log final cache and retention policy status for transparency

--- a/tests/test_worker_pool.py
+++ b/tests/test_worker_pool.py
@@ -131,5 +131,52 @@ class GovernorBackstopTests(unittest.TestCase):
         self.assertLess(gov.rate, 8.0)
 
 
+class RetryTests(unittest.TestCase):
+    def test_failed_task_is_retried_and_can_succeed(self):
+        attempts = {}
+        lock = threading.Lock()
+
+        def execute(session, task):
+            with lock:
+                attempts[task.task_id] = attempts.get(task.task_id, 0) + 1
+                n = attempts[task.task_id]
+            # task "2" fails on its first attempt, succeeds on the retry
+            ok = not (task.task_id == "2" and n == 1)
+            return DownloadResult(task.task_id, success=ok, rate_limited=not ok)
+
+        pool = PacedWorkerPool(execute, workers=1, governor=instant_governor())
+        results = pool.run(tasks(3), max_attempts=2)
+        self.assertEqual(len(results), 3)
+        self.assertTrue(next(r for r in results if r.task_id == "2").success)
+        self.assertEqual(attempts["2"], 2)  # retried once
+
+    def test_exhausted_retries_finalise_as_failure(self):
+        def execute(session, task):
+            return DownloadResult(task.task_id, success=False)
+
+        pool = PacedWorkerPool(execute, workers=2, governor=instant_governor())
+        results = pool.run(tasks(5), max_attempts=2)
+        self.assertEqual(len(results), 5)  # no deadlock; all finalised
+        self.assertTrue(all(not r.success for r in results))
+        self.assertEqual(pool.requests, 10)  # 5 tasks x 2 attempts
+
+    def test_default_is_no_retry(self):
+        def execute(session, task):
+            return DownloadResult(task.task_id, success=False)
+
+        pool = PacedWorkerPool(execute, workers=2, governor=instant_governor())
+        pool.run(tasks(4))
+        self.assertEqual(pool.requests, 4)  # one attempt each
+
+    def test_stats_count_requests_and_rate_limited(self):
+        def execute(session, task):
+            return DownloadResult(task.task_id, success=False, rate_limited=True)
+
+        pool = PacedWorkerPool(execute, workers=2, governor=instant_governor())
+        pool.run(tasks(4), max_attempts=1)
+        self.assertEqual(pool.requests, 4)
+        self.assertEqual(pool.rate_limited, 4)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to PR #13 (parallel downloads): cosmetic stats fix + retry/requeue.

## Cosmetic — accurate request stats in parallel mode

The final `HTTP requests: 0 total, 0 WAF blocks, 0.80s final delay` line came
from the sequential `OptimizedDownloader`, which is **not used** when workers>1
(the pool uses its own sessions) — so it always showed 0. The pool now tracks
its request / rate-limited counts; the downloaders surface them and the report
becomes:

```
Network requests: <N> total, <M> rate-limited/blocked
```

accurate whether the run was sequential or parallel.

## Retry / requeue on failure

`PacedWorkerPool.run(max_attempts=…)` now re-queues a failed task (including
rate-limited ones) **at the end** of the queue and retries it up to
`max_attempts`, with finalised-count termination (no deadlock when requeues are
in flight).

- **Guide blocks** retry harder (`max_attempts=3`) — they are important.
- **Series details** are best-effort (`max_attempts=2`, one end-of-queue retry);
  anything still missing is simply re-fetched on the next run (it stays
  uncached), per the discussion.

## Tests

Retry-then-succeed, exhausted-retries-finalise-as-failure, no-retry default, and
request/rate-limited stat counting. 91 tests pass; flake8 clean. Version
`2.0.0-dev5`.
