### PR TITLE
cache: split cache into guide/series/movies subdirectories

### DIFF
--- a/docs/cache-retention.md
+++ b/docs/cache-retention.md
@@ -172,31 +172,35 @@ Old settings are automatically migrated:
 
 ### Cache Directory Layout
 
-The cache directory keeps the small, frequently-rotated guide blocks at its
-root and stores the many per-series detail files in a `series/` subdirectory:
+The cache directory is organised into focused subdirectories, keeping the root
+clean for the generated guide and its backups:
 
 ```
 ~/gracenote2epg/cache/
-├── 2026061412.json.gz      # guide blocks (YYYYMMDDHH, 3-hour spans)
-├── 2026061415.json.gz
-├── ...
 ├── xmltv.xml               # generated guide
 ├── xmltv.xml.2026-06-13... # XMLTV backups
-└── series/                 # extended details, one file per series
-    ├── SH00012345.json
-    ├── MV00067890.json
-    └── EP00021161.json
+├── guide/                  # guide blocks (YYYYMMDDHH, 3-hour spans)
+│   ├── 2026061412.json.gz
+│   ├── 2026061415.json.gz
+│   └── ...
+├── series/                 # extended TV series details (IDs starting with SH)
+│   ├── SH00012345.json
+│   └── EP00021161.json
+└── movies/                 # extended movie details (IDs starting with MV)
+    └── MV00067890.json
 ```
 
-Older caches that stored series files directly at the cache root are migrated
-automatically on first run (the files are moved into `series/`, so nothing is
-re-downloaded).
+Older caches are migrated automatically on first run — guide blocks move into
+`guide/`, detail files are routed into `series/` or `movies/` by their ID
+prefix (including movies previously kept in `series/`), so nothing is
+re-downloaded.
 
 To inspect:
 
 ```bash
-ls -la ~/gracenote2epg/cache/*.json.gz      # guide blocks
+ls -la ~/gracenote2epg/cache/guide/         # guide blocks
 ls -la ~/gracenote2epg/cache/series/        # series details
+ls -la ~/gracenote2epg/cache/movies/        # movie details
 ```
 
 ### Cache Validation
@@ -261,7 +265,7 @@ grep -E "(redays|refresh|logrotate|relogs|rexmltv)" ~/gracenote2epg/conf/graceno
 
 Check guide cache:
 ```bash
-ls -la ~/gracenote2epg/cache/*.json.gz
+ls -la ~/gracenote2epg/cache/guide/
 ```
 
 Check log backups:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,9 +12,11 @@ packages (`config/`, `args/`, `parser/`, `downloader/`, `xmltv/`, `logrotate/`)
 with no change to the generated guide.
 
 ### Added
-- **Cache layout**: extended series details are now stored in a `series/`
-  subdirectory, keeping the cache root limited to guide blocks for easier
-  inspection. Legacy flat caches are migrated automatically on first run (no
+- **Cache layout**: the cache is organised into `guide/` (guide blocks),
+  `series/` (TV series details, `SH*`) and `movies/` (movie details, `MV*`)
+  subdirectories, keeping the cache root limited to the generated guide and its
+  backups for easier inspection. Older caches (flat layout, or the earlier
+  `series/`-only layout) are migrated automatically on first run (no
   re-download).
 - **Richer program metadata**: crew (directors/writers/producers) is now
   included and credits are emitted for TV series, not just movies; credits are

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,11 +27,12 @@ with no change to the generated guide.
 - **Configurable image source**: a new `<imagesources>` config block selects the
   image host (the first `enabled` source). Mirror hosts serve the same images;
   the default is `tmsimg.fancybits.co` since `www.tvtv.ca` is rate-limited.
-- **Parallel series downloads**: a bounded pool of keep-alive workers downloads
-  series details concurrently, governed by a self-regulating (AIMD) shared rate
-  limiter. Controlled by the new `dlworkers` setting (`1`=sequential, `2`-`8`
-  =fixed, `auto`=default). ~3.4× faster on the new-series delta of a refresh,
-  with no rotating User-Agents (a single one is sufficient). Config schema → 7.
+- **Parallel downloads**: a bounded pool of keep-alive workers fetches guide
+  blocks and series details concurrently, governed by a self-regulating (AIMD)
+  shared rate limiter. Controlled by the new `dlworkers` setting (`1`
+  =sequential, `2`-`8`=fixed, `auto`=default). ~3.4× faster on the new-series
+  delta of a refresh, with no rotating User-Agents (a single one is
+  sufficient). Config schema → 7.
 
 ### Fixed
 - **Timezone offset**: XMLTV times now always carry a standard signed `±HHMM`

--- a/docs/program-metadata.md
+++ b/docs/program-metadata.md
@@ -6,9 +6,10 @@ the candidates for enrichment.
 
 ## Sources
 
-- **Guide block** (`api/grid`, cached `YYYYMMDDHH.json.gz`): `channels[]` →
+- **Guide block** (`api/grid`, cached `guide/YYYYMMDDHH.json.gz`): `channels[]` →
   per-channel metadata + `events[]` → per-airing data + `events[].program{}`.
-- **Series details** (`api/program/overviewDetails`, cached `series/<id>.json`):
+- **Series details** (`api/program/overviewDetails`, cached `series/<id>.json`
+  for SH* IDs, `movies/<id>.json` for MV* IDs):
   series-level metadata + `overviewTab.{cast,crew}` + `upcomingEpisodeTab[]`
   (per-episode synopsis, ratings, flags, original air date, …).
 

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev4"
+__version__ = "2.0.0-dev5"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/cache.py
+++ b/gracenote2epg/cache.py
@@ -1,9 +1,10 @@
 """
 gracenote2epg.cache - Cache management
 
-Manages all caching operations for gracenote2epg: guide blocks, series
-details (stored under a series/ subdirectory), and XMLTV backups, with
-unified retention policies.
+Manages all caching operations for gracenote2epg. The cache is organised in
+subdirectories: guide/ for guide blocks, series/ for TV series details (SH*),
+movies/ for movie details (MV*); XMLTV files and their backups stay at the
+cache root. Includes unified retention policies.
 """
 
 import gzip
@@ -23,41 +24,65 @@ class CacheManager:
 
     def __init__(self, cache_dir: Path):
         self.cache_dir = Path(cache_dir)
-        # Series details live in a dedicated subdirectory so the cache root
-        # only holds the handful of guide blocks (YYYYMMDDHH.json.gz), keeping
-        # it small and easy to inspect manually.
+        # Organise the cache into focused subdirectories so the root stays clean
+        # and manual inspection is easy:
+        #   guide/  -> guide blocks (YYYYMMDDHH.json.gz)
+        #   series/ -> TV series details (SH*)
+        #   movies/ -> movie details (MV*)
+        # (xmltv.xml and its backups stay at the cache root.)
+        self.guide_dir = self.cache_dir / "guide"
         self.series_dir = self.cache_dir / "series"
+        self.movies_dir = self.cache_dir / "movies"
         # Create cache directories with proper 755 permissions (rwxr-xr-x)
-        for directory in (self.cache_dir, self.series_dir):
+        for directory in (self.cache_dir, self.guide_dir, self.series_dir, self.movies_dir):
             try:
                 directory.mkdir(parents=True, exist_ok=True, mode=0o755)
             except Exception:
                 # Fallback: create without mode specification (depends on umask)
                 directory.mkdir(parents=True, exist_ok=True)
-        # One-time migration: relocate any legacy flat series files (cached by
-        # older versions directly under the cache root) into series/ so existing
-        # caches are reused instead of re-downloaded.
-        self._migrate_legacy_series_cache()
+        # One-time migration of older cache layouts (no re-download).
+        self._migrate_cache_layout()
 
-    def _migrate_legacy_series_cache(self):
-        """Move legacy flat *.json series files into the series subdirectory."""
+    def _details_dir(self, series_id: str) -> Path:
+        """Subdirectory for a program's details: movies/ for MV*, else series/."""
+        return self.movies_dir if str(series_id).upper().startswith("MV") else self.series_dir
+
+    def _move_into(self, src: Path, dest_dir: Path) -> int:
+        """Move *src* into *dest_dir* unless already there; returns 1 if moved."""
+        target = dest_dir / src.name
         try:
-            legacy = [
+            if src.resolve() == target.resolve():
+                return 0
+            src.replace(target)
+            return 1
+        except Exception as e:
+            logging.debug("Could not migrate %s: %s", src.name, e)
+            return 0
+
+    def _migrate_cache_layout(self):
+        """Relocate files from older cache layouts into guide/series/movies."""
+        try:
+            moved = 0
+            # Guide blocks previously stored at the cache root -> guide/
+            for f in self.cache_dir.glob("*.json.gz"):
+                if f.is_file():
+                    moved += self._move_into(f, self.guide_dir)
+            # Detail files: legacy flat *.json at the root, plus MV* left in
+            # series/ by the first series/ layout -> the right subdirectory.
+            details = [
                 f
                 for f in self.cache_dir.glob("*.json")
                 if f.is_file() and not f.name.endswith(".json.gz")
             ]
-            if not legacy:
-                return
-            for cache_file in legacy:
-                target = self.series_dir / cache_file.name
-                try:
-                    cache_file.replace(target)
-                except Exception as e:
-                    logging.debug("Could not migrate cached series %s: %s", cache_file.name, e)
-            logging.info("Migrated %d cached series file(s) into %s", len(legacy), self.series_dir)
+            details += list(self.series_dir.glob("MV*.json"))
+            for f in details:
+                moved += self._move_into(f, self._details_dir(f.stem))
+            if moved:
+                logging.info(
+                    "Migrated %d cached file(s) into the guide/series/movies layout", moved
+                )
         except Exception as e:
-            logging.debug("Legacy series cache migration skipped: %s", e)
+            logging.debug("Cache layout migration skipped: %s", e)
 
     def backup_xmltv(self, xmltv_file: Path) -> Optional[Path]:
         """XMLTV: Always backup previous version"""
@@ -147,7 +172,7 @@ class CacheManager:
             invalid_count = 0
 
             # Process guide block files (format: YYYYMMDDHH.json.gz)
-            for cache_file in self.cache_dir.glob("*.json.gz"):
+            for cache_file in self.guide_dir.glob("*.json.gz"):
                 if len(cache_file.stem) == 10:  # YYYYMMDDHH
                     try:
                         date_str = cache_file.stem  # YYYYMMDDHH
@@ -203,8 +228,11 @@ class CacheManager:
             cleaned_count = 0
             kept_count = 0
 
-            # Process show detail files (stored under the series/ subdirectory)
-            for cache_file in self.series_dir.glob("*.json"):
+            # Process show/movie detail files (series/ and movies/ subdirectories)
+            detail_files = list(self.series_dir.glob("*.json")) + list(
+                self.movies_dir.glob("*.json")
+            )
+            for cache_file in detail_files:
                 series_id = cache_file.stem  # filename without .json
 
                 if series_id in active_series:
@@ -229,7 +257,7 @@ class CacheManager:
     def save_guide_block(self, filename: str, data: bytes) -> bool:
         """Save compressed guide block data"""
         try:
-            file_path = self.cache_dir / filename
+            file_path = self.guide_dir / filename
             with gzip.open(file_path, "wb") as f:
                 f.write(data)
             return True
@@ -240,7 +268,7 @@ class CacheManager:
     def load_guide_block(self, filename: str) -> Optional[bytes]:
         """Load compressed guide block data"""
         try:
-            file_path = self.cache_dir / filename
+            file_path = self.guide_dir / filename
             if file_path.exists():
                 with gzip.open(file_path, "rb") as f:
                     return f.read()
@@ -251,7 +279,7 @@ class CacheManager:
     def save_series_details(self, series_id: str, data: bytes) -> bool:
         """Save series details JSON data"""
         try:
-            file_path = self.series_dir / f"{series_id}.json"
+            file_path = self._details_dir(series_id) / f"{series_id}.json"
             with open(file_path, "wb") as f:
                 f.write(data)
             return True
@@ -261,7 +289,7 @@ class CacheManager:
 
     def load_series_details(self, series_id: str) -> Optional[Dict]:
         """Load series details JSON data"""
-        file_path = self.series_dir / f"{series_id}.json"
+        file_path = self._details_dir(series_id) / f"{series_id}.json"
         try:
             if file_path.exists() and file_path.stat().st_size > 0:
                 with open(file_path, "rb") as f:
@@ -299,7 +327,7 @@ class CacheManager:
         (absent while --norefresh prevents downloading). Mirrors the decision in
         download_guide_block_safe so the parallel path stays consistent.
         """
-        file_exists = (self.cache_dir / filename).exists()
+        file_exists = (self.guide_dir / filename).exists()
         if refresh_hours == 0:
             return "cached" if file_exists else "missing"
         if not file_exists:
@@ -311,7 +339,7 @@ class CacheManager:
         self, downloader, grid_time: float, filename: str, url: str, refresh_hours: int = 48
     ) -> bool:
         """Safe download of guide block with automatic backup"""
-        file_path = self.cache_dir / filename
+        file_path = self.guide_dir / filename
         file_exists = file_path.exists()
 
         # Handling for --norefresh (refresh_hours == 0)

--- a/gracenote2epg/downloader/guide.py
+++ b/gracenote2epg/downloader/guide.py
@@ -113,7 +113,7 @@ class GuideDownloader(DownloaderStatsMixin):
                 logging.warning("Block %s not in cache and --norefresh prevents download", filename)
                 self.failed_count += 1
             else:  # fetch
-                existed = (self.cache_manager.cache_dir / filename).exists()
+                existed = (self.cache_manager.guide_dir / filename).exists()
                 to_fetch.append((filename, existed))
                 tasks.append(
                     DownloadTask(

--- a/tests/test_cache_migration.py
+++ b/tests/test_cache_migration.py
@@ -1,4 +1,4 @@
-"""Tests for CacheManager: series/ subdirectory layout and legacy migration."""
+"""Tests for CacheManager: guide/series/movies layout and legacy migration."""
 
 import json
 import tempfile
@@ -13,36 +13,72 @@ class CacheLayoutTests(unittest.TestCase):
         self.tmp = tempfile.mkdtemp()
         self.cache_dir = Path(self.tmp) / "cache"
 
-    def test_series_dir_created(self):
+    def test_subdirs_created(self):
         cm = CacheManager(self.cache_dir)
+        self.assertTrue(cm.guide_dir.is_dir())
         self.assertTrue(cm.series_dir.is_dir())
+        self.assertTrue(cm.movies_dir.is_dir())
+        self.assertEqual(cm.guide_dir, self.cache_dir / "guide")
         self.assertEqual(cm.series_dir, self.cache_dir / "series")
+        self.assertEqual(cm.movies_dir, self.cache_dir / "movies")
 
-    def test_series_saved_under_subdir(self):
+    def test_series_saved_under_series_subdir(self):
         cm = CacheManager(self.cache_dir)
         cm.save_series_details("SH00012345", json.dumps({"ok": 1}).encode("utf-8"))
         self.assertTrue((cm.series_dir / "SH00012345.json").exists())
+        self.assertFalse((cm.movies_dir / "SH00012345.json").exists())
         self.assertFalse((self.cache_dir / "SH00012345.json").exists())
+
+    def test_movie_saved_under_movies_subdir(self):
+        cm = CacheManager(self.cache_dir)
+        cm.save_series_details("MV00067890", json.dumps({"title": "x"}).encode("utf-8"))
+        self.assertTrue((cm.movies_dir / "MV00067890.json").exists())
+        self.assertFalse((cm.series_dir / "MV00067890.json").exists())
 
     def test_save_load_roundtrip(self):
         cm = CacheManager(self.cache_dir)
         cm.save_series_details("MV00067890", json.dumps({"title": "x"}).encode("utf-8"))
         self.assertEqual(cm.load_series_details("MV00067890"), {"title": "x"})
 
-    def test_legacy_flat_series_are_migrated(self):
-        # Simulate an old cache: flat series files + a guide block at the root.
+    def test_guide_block_saved_under_guide_subdir(self):
+        cm = CacheManager(self.cache_dir)
+        cm.save_guide_block("2026061412.json.gz", b"\x1f\x8b guide")
+        self.assertTrue((cm.guide_dir / "2026061412.json.gz").exists())
+        self.assertFalse((self.cache_dir / "2026061412.json.gz").exists())
+        self.assertEqual(cm.load_guide_block("2026061412.json.gz"), b"\x1f\x8b guide")
+
+    def test_legacy_flat_layout_is_migrated(self):
+        # Simulate an old cache: flat detail files + a guide block at the root.
         self.cache_dir.mkdir(parents=True)
         (self.cache_dir / "SH99999999.json").write_text('{"legacy": true}')
+        (self.cache_dir / "MV88888888.json").write_text('{"film": true}')
         (self.cache_dir / "2026061412.json.gz").write_bytes(b"\x1f\x8b guide")
 
         cm = CacheManager(self.cache_dir)
 
-        # Series file moved into series/, guide block left at the root.
+        # Detail files routed by prefix, guide block moved into guide/.
         self.assertFalse((self.cache_dir / "SH99999999.json").exists())
         self.assertTrue((cm.series_dir / "SH99999999.json").exists())
-        self.assertTrue((self.cache_dir / "2026061412.json.gz").exists())
-        # And it is reusable (no re-download needed).
+        self.assertTrue((cm.movies_dir / "MV88888888.json").exists())
+        self.assertFalse((self.cache_dir / "2026061412.json.gz").exists())
+        self.assertTrue((cm.guide_dir / "2026061412.json.gz").exists())
+        # And they are reusable (no re-download needed).
         self.assertEqual(cm.load_series_details("SH99999999"), {"legacy": True})
+        self.assertEqual(cm.load_series_details("MV88888888"), {"film": True})
+
+    def test_movies_left_in_series_dir_are_migrated(self):
+        # First series/ layout stored movies in series/ too; relocate them.
+        series_dir = self.cache_dir / "series"
+        series_dir.mkdir(parents=True)
+        (series_dir / "MV12121212.json").write_text('{"film": 1}')
+        (series_dir / "SH13131313.json").write_text('{"show": 1}')
+
+        cm = CacheManager(self.cache_dir)
+
+        self.assertFalse((cm.series_dir / "MV12121212.json").exists())
+        self.assertTrue((cm.movies_dir / "MV12121212.json").exists())
+        # Series stay put.
+        self.assertTrue((cm.series_dir / "SH13131313.json").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

**Cosmetic** reorganization of the cache so the root stays clean: only the generated XMLTV and its backups remain there.

- `guide/` → guide blocks (`YYYYMMDDHH.json.gz`)
- `series/` → TV series details (IDs `SH*`)
- `movies/` → movie details (IDs `MV*`, new)

Routing is centralized in `CacheManager` (`_details_dir()`); **no change to the public interface**.

## Automatic migration

On first run, with no re-download:
- guide blocks at the root → `guide/`
- flat detail files at the root → `series/`/`movies/` by ID prefix
- `MV*` files left in `series/` (earlier `series/`-only layout) → `movies/`

## Tests

- `tests/test_cache_migration.py` rewritten: subdirectories created, SH/MV routing, migration of the three legacy cases.
- Full suite (90 tests) green, `black` + `flake8` clean.

> Note: branched off `main` (2.0.0-dev4), independent of #14. Version bump → 2.0.0-dev5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
