### PR TITLE
parser: apply series details to every airing, not just the first

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,13 @@ with no change to the generated guide.
   with no rotating User-Agents (a single one is sufficient). Config schema → 7.
 
 ### Fixed
+- **Series details on every airing**: extended details (series box-art `<icon>`,
+  credits, genres, per-episode synopsis and original air date) were only applied
+  to the *first* airing of each series in the guide. Every other airing fell
+  back to the per-episode thumbnail as `<icon>` and lost its credits/genres/
+  poster — so the same series looked rich on one showing and bare on the next.
+  Details are now applied to all airings (the per-series cache file is still read
+  from disk only once).
 - **Timezone offset**: XMLTV times now always carry a standard signed `±HHMM`
   offset. UTC hosts previously emitted `0000` (no sign), and offsets with
   non-zero minutes (e.g. Newfoundland `-0330`, India `+0530`) were truncated.

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev4"
+__version__ = "2.0.0-dev5"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/parser/base.py
+++ b/gracenote2epg/parser/base.py
@@ -119,8 +119,16 @@ class DataParser:
             grid_time += 10800  # Next 3-hour block
 
     def _apply_series_details_to_schedule(self):
-        """Apply downloaded series details to parsed episodes - pure parsing logic"""
-        processed_series = set()
+        """Apply downloaded series details to every airing - pure parsing logic.
+
+        The details (series image/box art, credits, genres, per-episode synopsis
+        and original air date) must be applied to *each* airing of a series, not
+        just the first one seen. We only cache the per-series disk read so the
+        same JSON isn't reloaded for every airing; applying it stays per-episode
+        (and is in fact more accurate, since synopsis/air-date are matched by the
+        airing's own episode id).
+        """
+        details_by_series = {}  # series_id -> loaded details (or None), cached per disk read
 
         for station_id, station_data in self.schedule.items():
             for episode_key, episode_data in station_data.items():
@@ -128,16 +136,18 @@ class DataParser:
                     continue  # Skip channel metadata
 
                 series_id = episode_data.get("epseries")
-                if not series_id or series_id in processed_series:
+                if not series_id:
                     continue
 
-                # Get cached series details (already downloaded)
-                series_details = self.series_downloader.get_cached_series_details(series_id)
+                if series_id not in details_by_series:
+                    details_by_series[series_id] = self.series_downloader.get_cached_series_details(
+                        series_id
+                    )
+                series_details = details_by_series[series_id]
 
                 if series_details:
-                    # Pure parsing - apply details to episode data
+                    # Pure parsing - apply details to this airing's episode data
                     self.series_parser.parse_series_details(episode_data, series_details, series_id)
-                    processed_series.add(series_id)
 
     def get_active_series_list(self) -> List[str]:
         """Extract list of active series from current schedule"""

--- a/tests/test_series_application.py
+++ b/tests/test_series_application.py
@@ -1,0 +1,84 @@
+"""Regression test: series details must enrich EVERY airing, not just the first.
+
+A single series airs many times across the guide (e.g. a daily soap). The
+extended details (box-art image, credits, genres, synopsis) must be applied to
+each airing; an earlier version stopped after the first airing of each series,
+leaving later airings with only the per-episode thumbnail as <icon>.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from gracenote2epg.cache import CacheManager
+from gracenote2epg.parser.base import DataParser
+
+
+SERIES_DETAILS = {
+    "seriesImage": "p183907_b_h9_at",  # box art (_b_)
+    "backgroundImage": "p183907_i_h10_ag",
+    "seriesGenres": "Drama|Romance",
+    "seriesDescription": "Generic series blurb.",
+    "overviewTab": {"cast": [{"role": "Actor", "name": "Jane Star"}], "crew": []},
+    "upcomingEpisodeTab": [],
+}
+
+
+class ApplyToEveryAiringTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dp = DataParser(CacheManager(Path(self.tmp) / "cache"))
+
+        self.reads = []  # series_ids read from disk
+
+        def fake_get(series_id):
+            self.reads.append(series_id)
+            return SERIES_DETAILS if series_id == "EP00041092" else None
+
+        self.dp.series_downloader.get_cached_series_details = fake_get
+
+    def _airing(self, epid):
+        return {"epseries": "EP00041092", "epid": epid, "epimage": None, "epfan": None}
+
+    def test_all_airings_of_a_series_are_enriched(self):
+        self.dp.schedule = {
+            "72755": {
+                "ch72755": {"name": "channel meta"},  # must be skipped
+                "ep1": self._airing("EP000410923395"),
+                "ep2": self._airing("EP000410923396"),
+                "ep3": self._airing("EP000410923397"),
+            }
+        }
+
+        self.dp._apply_series_details_to_schedule()
+
+        sched = self.dp.schedule["72755"]
+        for key in ("ep1", "ep2", "ep3"):
+            self.assertEqual(
+                sched[key]["epimage"],
+                "p183907_b_h9_at",
+                f"{key} should get the series box-art image",
+            )
+            self.assertEqual(sched[key]["epfan"], "p183907_i_h10_ag")
+            self.assertIn("epcredits", sched[key], f"{key} should get credits")
+
+    def test_disk_is_read_once_per_series(self):
+        self.dp.schedule = {
+            "72755": {
+                "ep1": self._airing("EP000410923395"),
+                "ep2": self._airing("EP000410923396"),
+            }
+        }
+        self.dp._apply_series_details_to_schedule()
+        # Cached per series: one disk read even though there are two airings.
+        self.assertEqual(self.reads, ["EP00041092"])
+
+    def test_series_without_details_left_untouched(self):
+        ep = {"epseries": "SH99999999", "epid": "x", "epimage": None}
+        self.dp.schedule = {"72755": {"ep1": ep}}
+        self.dp._apply_series_details_to_schedule()
+        self.assertIsNone(ep["epimage"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

`_apply_series_details_to_schedule()` only applied the extended details to the **first airing seen** of each series (a `processed_series` guard). Every other airing of the same series:
- lost the series box-art `<icon>` → fell back to the **per-episode thumbnail** (`_e_`, not meaningful),
- lost credits, genres, poster/backdrop and the per-episode synopsis.

Hence the observed symptom: the **same** series looks rich on one showing and bare on the next (e.g. the daily soap "Top modèles", Magnum P.I., both US **and** French-language series).

### Concrete example ("Top modèles", two consecutive days)
- Jun 15 (first seen): `<icon>` = `p183907_b_h9_at` (box art), poster+backdrop+still, credits ✓
- Jun 16: `<icon>` = `p30899344_e_v9_aa` (episode), **only** `<image type="still">`, no credits ✗

## The fix

Apply the details to **every** airing. The per-series JSON is still read from disk **only once** (cached in a dict); applying stays per-episode, which is also **more accurate** (synopsis / original air date are matched by each airing's own `epid`).

## Tests
- New `tests/test_series_application.py`: every airing of a series is enriched, disk is read once per series, series without details are left untouched.
- Full suite (90 tests) green, `black` + `flake8` clean. The golden test is unaffected (it feeds a pre-built schedule and does not go through this loop).

> Branched off `main` (2.0.0-dev4), independent of #14/#15. Version bump → 2.0.0-dev5 (to be reconciled at merge, like the others).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
