### PR TITLE
downloader: sequential fallback + early-abort to survive the 429 wall

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,9 +32,18 @@ with no change to the generated guide.
   shared rate limiter. Controlled by the new `dlworkers` setting (`1`
   =sequential, `2`-`8`=fixed, `auto`=default). ~3.4× faster on the new-series
   delta of a refresh, with no rotating User-Agents (a single one is
-  sufficient). Config schema → 7. Failed downloads are re-queued (guide retried
-  harder than non-critical series details), and the final stats report the
-  pool's request counts accurately.
+  sufficient). Failed downloads are re-queued (guide retried harder than
+  non-critical series details), and the final stats report the pool's request
+  counts accurately.
+- **Cold-cache rate-limit handling**: the Gracenote API blocks (HTTP 429) after
+  a few hundred requests, which concurrency reaches sooner. A new `dlthreshold`
+  setting (`auto`≈500) downloads large series-detail batches **sequentially**
+  (never rate-limited) while keeping the parallel pool for normal refreshes. As
+  a safety net, the parallel pool now **aborts early** if the server keeps
+  returning 429 (instead of crawling forever), logs blocks/back-offs at WARNING,
+  and **saves details as they arrive** — so an interrupted or aborted run keeps
+  its progress, the rest is fetched next run, and the process always terminates
+  on its own. Config schema → 8.
 
 ### Fixed
 - **Series details on every airing**: extended details (series box-art `<icon>`,
@@ -59,9 +68,10 @@ with no change to the generated guide.
   Behaviour verified byte-for-byte identical against the pre-refactor output.
 - **Geographic resolution is now built in**: postal/ZIP → city/province uses a
   small bundled GeoNames dataset read with the standard library.
-- **Config schema versions 6 and 7**: v6 introduces the `<imagesources>` block,
-  v7 the `dlworkers` setting. Older configs are upgraded automatically on the
-  next run (a backup is written and the new defaults are injected).
+- **Config schema versions 6, 7 and 8**: v6 introduces the `<imagesources>`
+  block, v7 the `dlworkers` setting, v8 the `dlthreshold` setting. Older configs
+  are upgraded automatically on the next run (a backup is written and the new
+  defaults are injected).
 
 ### Removed
 - **`pgeocode` dependency** (and its transitive `pandas`/`numpy` chain), which

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ gracenote2epg auto-detects your system and uses appropriate directories:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="7">
+<settings version="8">
   <!-- Basic guide settings -->
   <setting id="zipcode">92101</setting>                        <!-- US ZIP or Canadian postal code -->
   <setting id="lineupid">auto</setting>                        <!-- Lineup configuration -->
@@ -60,6 +60,7 @@ gracenote2epg auto-detects your system and uses appropriate directories:
 
   <!-- Download performance -->
   <setting id="dlworkers">auto</setting>                       <!-- Parallel download workers: 1=sequential, 2-8=fixed, auto=recommended -->
+  <setting id="dlthreshold">auto</setting>                     <!-- Switch to sequential above N pending downloads (avoids 429 wall): auto(~500) or a number -->
 
   <!-- Image source host (first 'enabled' is used) -->
   <imagesources>
@@ -71,9 +72,10 @@ gracenote2epg auto-detects your system and uses appropriate directories:
 </settings>
 ```
 
-> **Schema versions 6 / 7**: v6 added the `<imagesources>` block, v7 the
-> `dlworkers` setting. Older configs are upgraded automatically on the next run
-> (a backup is written and the new defaults are injected).
+> **Schema versions 6 / 7 / 8**: v6 added the `<imagesources>` block, v7 the
+> `dlworkers` setting, v8 the `dlthreshold` setting. Older configs are upgraded
+> automatically on the next run (a backup is written and the new defaults are
+> injected).
 
 ## Download Performance
 
@@ -88,6 +90,20 @@ gracenote2epg auto-detects your system and uses appropriate directories:
 Parallel workers each reuse one persistent connection and share a combined-rate
 governor, so a refresh's new-series delta downloads ~3× faster without tripping
 the server. There is a single data host (no alternate source to configure).
+
+`dlthreshold` guards the cold-cache case. The Gracenote API enforces a
+cumulative-volume wall (HTTP 429) after a few hundred requests, which concurrency
+reaches sooner; a single sequential connection is never blocked. So when the
+number of series details to fetch reaches `dlthreshold`, the run downloads them
+sequentially (slower but reliable); below it, the parallel pool is used.
+
+- `auto` (default) — the observed wall, ~500.
+- a positive integer — an explicit batch size to switch at.
+
+As a safety net, even in parallel mode the pool aborts early if the server keeps
+returning 429 (instead of crawling), and details are saved as they arrive, so a
+partial/aborted run keeps its progress and the rest is fetched on the next run —
+the process always terminates on its own.
 
 ## Image Source
 
@@ -335,7 +351,7 @@ Same format as `relogs` - controls how long to keep XMLTV backup files.
 ### Standard Home Setup
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="7">
+<settings version="8">
   <!-- Basic guide settings -->
   <setting id="zipcode">92101</setting>
   <setting id="lineupid">auto</setting>
@@ -358,7 +374,7 @@ Same format as `relogs` - controls how long to keep XMLTV backup files.
 ### Resource-Limited System
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="7">
+<settings version="8">
   <!-- Minimal resource usage -->
   <setting id="zipcode">J3B1M4</setting>
   <setting id="lineupid">auto</setting>
@@ -381,7 +397,7 @@ Same format as `relogs` - controls how long to keep XMLTV backup files.
 ### Development/Testing
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="7">
+<settings version="8">
   <!-- Testing configuration -->
   <setting id="zipcode">92101</setting>
   <setting id="lineupid">auto</setting>

--- a/gracenote2epg.xml
+++ b/gracenote2epg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<settings version="7">
+<settings version="8">
   <!-- Basic guide settings -->
   <setting id="days">7</setting>                               <!-- Guide duration (1-14 days) -->
   <setting id="zipcode">92101</setting>                        <!-- US ZIP or Canadian postal code -->
@@ -41,6 +41,7 @@
 
   <!-- Download performance -->
   <setting id="dlworkers">auto</setting>                       <!-- Parallel download workers: 1=sequential, 2-8=fixed, auto=recommended -->
+  <setting id="dlthreshold">auto</setting>                     <!-- Switch to sequential above N pending downloads (avoids 429 wall): auto(~500) or a number -->
 
   <!-- Image source host: the first 'enabled' source is used for program/cast   -->
   <!-- images. Mirrors serve the same images; switch by toggling status         -->

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev6"
+__version__ = "2.0.0-dev7"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/config/base.py
+++ b/gracenote2epg/config/base.py
@@ -117,6 +117,30 @@ class ConfigManager:
         except (TypeError, ValueError):
             return self.AUTO_DOWNLOAD_WORKERS
 
+    # Pending-download count above which series details switch to sequential.
+    # The Gracenote API WAF blocks (HTTP 429) after a few hundred requests, and
+    # the cumulative wall is reached around ~500; staying parallel only below it
+    # keeps the speed win for normal refreshes while a cold rebuild (a large
+    # batch) goes sequential, which the server never rate-limits.
+    AUTO_DOWNLOAD_THRESHOLD = 500
+
+    def get_download_threshold(self) -> int:
+        """Parallel→sequential switch point from ``dlthreshold``.
+
+        When the number of series details to download is at or above this value,
+        the run uses a single sequential connection (which never trips the WAF);
+        below it, the parallel worker pool is used. ``auto`` (default) = ~the
+        observed WAF wall; a positive integer overrides it. ``0``/unknown → auto.
+        """
+        value = str(self.settings.get("dlthreshold", "auto")).strip().lower()
+        if value == "auto":
+            return self.AUTO_DOWNLOAD_THRESHOLD
+        try:
+            parsed = int(value)
+            return parsed if parsed > 0 else self.AUTO_DOWNLOAD_THRESHOLD
+        except (TypeError, ValueError):
+            return self.AUTO_DOWNLOAD_THRESHOLD
+
     def _parse_and_migrate_config(self):
         """Parse configuration file and handle migration if needed"""
         # Parse configuration file

--- a/gracenote2epg/config/settings.py
+++ b/gracenote2epg/config/settings.py
@@ -15,13 +15,14 @@ class SettingsManager:
     """Handles XML settings parsing and management"""
 
     # Current config schema version. Bumped to 6 for the <imagesources> block,
-    # then 7 for the dlworkers (parallel download) setting; older files are
-    # upgraded automatically on load.
-    CONFIG_VERSION = "7"
+    # 7 for the dlworkers (parallel download) setting, then 8 for the dlthreshold
+    # (parallel→sequential switch) setting; older files are upgraded
+    # automatically on load.
+    CONFIG_VERSION = "8"
 
     # Default configuration template
     DEFAULT_CONFIG = """<?xml version="1.0" encoding="utf-8"?>
-<settings version="7">
+<settings version="8">
   <!-- Basic guide settings -->
   <setting id="zipcode">92101</setting>
   <setting id="lineupid">auto</setting>
@@ -58,6 +59,7 @@ class SettingsManager:
 
   <!-- Download performance -->
   <setting id="dlworkers">auto</setting>
+  <setting id="dlthreshold">auto</setting>
 
   <!-- Image source host (first 'enabled' is used; mirrors serve the same images) -->
   <imagesources>
@@ -104,6 +106,7 @@ class SettingsManager:
         "relogs",
         "rexmltv",
         "dlworkers",
+        "dlthreshold",
     ]
 
     def __init__(self):
@@ -271,7 +274,7 @@ class SettingsManager:
                     "Cache and retention policies",
                     ["redays", "refresh", "logrotate", "relogs", "rexmltv"],
                 ),
-                ("Download performance", ["dlworkers"]),
+                ("Download performance", ["dlworkers", "dlthreshold"]),
             ]
 
             written_settings = set()
@@ -349,6 +352,7 @@ class SettingsManager:
             "relogs": "30",
             "rexmltv": "7",
             "dlworkers": "auto",
+            "dlthreshold": "auto",
         }
 
         # Decide what is missing from the ORIGINAL file (not the live, possibly

--- a/gracenote2epg/config/validation.py
+++ b/gracenote2epg/config/validation.py
@@ -48,6 +48,7 @@ class ConfigValidator:
             "rexmltv": str,
             # Download performance
             "dlworkers": str,
+            "dlthreshold": str,
         }
 
     def validate_postal_code_format(self, postal_code: str) -> Tuple[bool, str, str]:

--- a/gracenote2epg/downloader/series.py
+++ b/gracenote2epg/downloader/series.py
@@ -28,13 +28,18 @@ class SeriesDownloader(DownloaderStatsMixin):
         self.failed_series: List[str] = []
         self.cached_series: Set[str] = set()
 
-    def download_series_details(self, series_list: List[str], workers: int = 1) -> bool:
+    def download_series_details(
+        self, series_list: List[str], workers: int = 1, threshold: int = 0
+    ) -> bool:
         """
         Download extended details for series with intelligent caching
 
         Args:
             series_list: List of series IDs to download
             workers: parallel download workers (1 = sequential)
+            threshold: if >0 and the number of downloads needed reaches it, fall
+                back to a single sequential connection (which the Gracenote WAF
+                never rate-limits) instead of the parallel pool
 
         Returns:
             bool: True if 70%+ successful
@@ -58,6 +63,18 @@ class SeriesDownloader(DownloaderStatsMixin):
             len(to_download),
             workers,
         )
+
+        # Large cold-cache batches trip the Gracenote rate-limit wall (HTTP 429)
+        # under concurrency; the server never blocks a single sequential
+        # connection, so switch to it above the configured threshold.
+        if workers > 1 and threshold and len(to_download) >= threshold:
+            logging.warning(
+                "Large batch (%d ≥ dlthreshold %d): downloading sequentially to avoid the "
+                "Gracenote rate-limit wall (HTTP 429); this is slower but reliable.",
+                len(to_download),
+                threshold,
+            )
+            workers = 1
 
         if workers > 1 and to_download:
             self._download_parallel(to_download, workers)
@@ -87,16 +104,39 @@ class SeriesDownloader(DownloaderStatsMixin):
         return download_success_rate >= 70 or attempted == 0
 
     def _download_parallel(self, to_download: List[str], workers: int) -> None:
-        """Download series details with a bounded keep-alive worker pool."""
+        """Download series details with a bounded keep-alive worker pool.
+
+        Each result is saved as soon as it finalises (save-as-you-go), so an
+        interrupted or early-aborted run keeps everything fetched so far.
+        """
+        import threading
+
         from .http import make_session, execute
         from .tasks import DownloadTask
         from .worker_pool import PacedWorkerPool
 
         total = len(to_download)
+        tally_lock = threading.Lock()
 
         def on_progress(done: int, _total: int):
             if done == 1 or done % max(1, total // 10) == 0 or done == total:
                 logging.info("  Extended details: %d/%d", done, total)
+
+        def on_result(result) -> None:
+            # Runs in worker threads as each download finalises.
+            saved = False
+            if result.success and result.content:
+                try:
+                    json.loads(result.content)  # validate JSON
+                    saved = self.cache_manager.save_series_details(result.task_id, result.content)
+                except json.JSONDecodeError:
+                    logging.warning("  Invalid JSON received for: %s", result.task_id)
+            with tally_lock:
+                if saved:
+                    self.downloaded_count += 1
+                else:
+                    self.failed_count += 1
+                    self.failed_series.append(result.task_id)
 
         tasks = [
             DownloadTask(
@@ -109,23 +149,18 @@ class SeriesDownloader(DownloaderStatsMixin):
         ]
 
         pool = PacedWorkerPool(
-            execute, workers=workers, session_factory=make_session, on_progress=on_progress
+            execute,
+            workers=workers,
+            session_factory=make_session,
+            on_progress=on_progress,
+            on_result=on_result,
         )
         # Series details are non-critical: one best-effort retry (re-queued at
-        # the end), and anything still missing is simply re-fetched next run.
-        for result in pool.run(tasks, max_attempts=2):
-            saved = False
-            if result.success and result.content:
-                try:
-                    json.loads(result.content)  # validate JSON
-                    saved = self.cache_manager.save_series_details(result.task_id, result.content)
-                except json.JSONDecodeError:
-                    logging.warning("  Invalid JSON received for: %s", result.task_id)
-            if saved:
-                self.downloaded_count += 1
-            else:
-                self.failed_count += 1
-                self.failed_series.append(result.task_id)
+        # the end). If the server keeps rate-limiting, the pool aborts early and
+        # anything still missing is simply re-fetched on the next run.
+        pool.run(tasks, max_attempts=2)
+        self.http_requests = pool.requests
+        self.rate_limited = pool.rate_limited
 
         self.http_requests = pool.requests
         self.rate_limited = pool.rate_limited

--- a/gracenote2epg/downloader/worker_pool.py
+++ b/gracenote2epg/downloader/worker_pool.py
@@ -8,6 +8,12 @@ downloads its share serially over a reused connection. A single shared
 on a rate-limit / WAF signal — a safety backstop that stays out of the way on
 normal small refreshes. See docs/parallel-download-redesign.md.
 
+If the server keeps returning HTTP 429 (its cumulative-volume wall), the pool
+gives up early instead of crawling forever: after a run of consecutive
+rate-limited responses it aborts the remaining queue (accounting those items as
+failed) so the process always terminates without a manual kill. The leftover
+work is simply picked up on the next run.
+
 The session factory and the per-task execute function are injected, so the pool
 is fully testable without any network.
 """
@@ -23,6 +29,7 @@ from .tasks import DownloadResult, DownloadTask
 # (session, task) -> DownloadResult
 ExecuteFn = Callable[[object, DownloadTask], DownloadResult]
 ProgressFn = Callable[[int, int], None]
+ResultFn = Callable[[DownloadResult], None]
 
 
 class PacedWorkerPool:
@@ -36,6 +43,8 @@ class PacedWorkerPool:
         session_factory: Optional[Callable[[], object]] = None,
         governor: Optional[RateController] = None,
         on_progress: Optional[ProgressFn] = None,
+        on_result: Optional[ResultFn] = None,
+        abort_after: int = 12,
     ):
         self._execute = execute
         self._workers = max(1, workers)
@@ -52,15 +61,26 @@ class PacedWorkerPool:
             decrease_factor=0.5,
         )
         self._on_progress = on_progress
+        self._on_result = on_result
+        # Stop hitting the server after this many consecutive rate-limited
+        # responses (0 = never abort). Guards against an endless crawl when the
+        # WAF wall stays shut.
+        self._abort_after = abort_after
         self._gov_lock = threading.Lock()
         self._stats_lock = threading.Lock()
+        self._abort = threading.Event()
         # Aggregate request stats (one entry per attempt), for reporting.
         self.requests = 0
         self.rate_limited = 0
+        self._consecutive_rate_limited = 0
 
     @property
     def governor(self) -> RateController:
         return self._governor
+
+    @property
+    def aborted(self) -> bool:
+        return self._abort.is_set()
 
     def run(self, tasks: List[DownloadTask], max_attempts: int = 1) -> List[DownloadResult]:
         """Execute *tasks*; returns their final results (order not guaranteed).
@@ -68,19 +88,22 @@ class PacedWorkerPool:
         Failed tasks (including rate-limited ones) are re-queued at the **end**
         and retried up to ``max_attempts`` total, so a transient/blocked request
         is given another chance after the rest of the batch (and after the
-        governor has backed off).
+        governor has backed off). If the server keeps rate-limiting, the pool
+        aborts early (see module docstring) rather than looping.
         """
         if not tasks:
             return []
         self.requests = 0
         self.rate_limited = 0
+        self._consecutive_rate_limited = 0
+        self._abort.clear()
 
         # Queue carries (task, attempt_number).
         work: "queue.Queue" = queue.Queue()
         for task in tasks:
             work.put((task, 1))
 
-        sink = _ResultSink(len(tasks), self._on_progress)
+        sink = _ResultSink(len(tasks), self._on_progress, self._on_result)
         n = min(self._workers, len(tasks))
         threads = [
             threading.Thread(target=self._worker_loop, args=(work, sink, max_attempts), daemon=True)
@@ -103,8 +126,13 @@ class PacedWorkerPool:
                     task, attempt = work.get(timeout=0.1)
                 except queue.Empty:
                     continue
+                if self._abort.is_set():
+                    # Don't touch the server any more; account the item as failed
+                    # so the pool finishes promptly instead of crawling.
+                    sink.add(DownloadResult(task.task_id, success=False, error="aborted"))
+                    continue
                 result = self._process(session, task)
-                if not result.success and attempt < max_attempts:
+                if not result.success and attempt < max_attempts and not self._abort.is_set():
                     logging.debug("Requeue %s (attempt %d/%d)", task.task_id, attempt, max_attempts)
                     work.put((task, attempt + 1))
                 else:
@@ -118,6 +146,7 @@ class PacedWorkerPool:
         """Pace (governed combined rate), run one request, feed the governor."""
         with self._gov_lock:
             self._governor.wait()
+        logging.debug("Downloading %s", task.task_id)
         try:
             result = self._execute(session, task)
         except Exception as e:  # never let one task kill a worker
@@ -128,26 +157,57 @@ class PacedWorkerPool:
                 self._governor.on_rate_limited()
             elif result.success:
                 self._governor.on_success()
+        self._record(result)
+        return result
+
+    def _record(self, result: DownloadResult) -> None:
+        """Update stats and trip the early-abort once the wall stays shut."""
         with self._stats_lock:
             self.requests += 1
             if result.rate_limited:
                 self.rate_limited += 1
-        return result
+                self._consecutive_rate_limited += 1
+            elif result.success:
+                self._consecutive_rate_limited = 0
+            consecutive = self._consecutive_rate_limited
+        if result.rate_limited:
+            logging.warning(
+                "Rate-limited/blocked (HTTP %s) on %s",
+                result.http_code or "?",
+                result.task_id,
+            )
+        if self._abort_after and consecutive >= self._abort_after and not self._abort.is_set():
+            self._abort.set()
+            logging.warning(
+                "Server rate-limited %d requests in a row (HTTP 429); stopping the parallel "
+                "batch early. The remaining items will be downloaded on the next run.",
+                consecutive,
+            )
 
 
 class _ResultSink:
-    """Thread-safe result collector with progress reporting."""
+    """Thread-safe result collector with progress + per-result callbacks."""
 
-    def __init__(self, total: int, on_progress: Optional[ProgressFn]):
+    def __init__(
+        self,
+        total: int,
+        on_progress: Optional[ProgressFn],
+        on_result: Optional[ResultFn] = None,
+    ):
         self.results: List[DownloadResult] = []
         self._total = total
         self._on_progress = on_progress
+        self._on_result = on_result
         self._lock = threading.Lock()
 
     def add(self, result: DownloadResult) -> None:
         with self._lock:
             self.results.append(result)
             done = len(self.results)
+        # Persist/handle this result as soon as it is final (save-as-you-go), so
+        # an interrupted or aborted run keeps everything fetched so far.
+        if self._on_result:
+            self._on_result(result)
         if self._on_progress:
             self._on_progress(done, self._total)
 

--- a/gracenote2epg/main.py
+++ b/gracenote2epg/main.py
@@ -354,7 +354,8 @@ def main():
             # Download extended details if needed
             if config_manager.needs_extended_download():
                 extended_success = data_parser.download_and_parse_series_details(
-                    workers=config_manager.get_download_workers()
+                    workers=config_manager.get_download_workers(),
+                    threshold=config_manager.get_download_threshold(),
                 )
                 if not extended_success:
                     logging.warning(

--- a/gracenote2epg/parser/base.py
+++ b/gracenote2epg/parser/base.py
@@ -70,7 +70,7 @@ class DataParser:
 
         return download_success
 
-    def download_and_parse_series_details(self, workers: int = 1) -> bool:
+    def download_and_parse_series_details(self, workers: int = 1, threshold: int = 0) -> bool:
         """Download and parse extended series details with separated logic"""
         # Extract active series list from parsed schedule
         series_list = self.get_active_series_list()
@@ -80,7 +80,9 @@ class DataParser:
             return True
 
         # PHASE 1: Download series details (delegated to downloader)
-        download_success = self.series_downloader.download_series_details(series_list, workers)
+        download_success = self.series_downloader.download_series_details(
+            series_list, workers, threshold
+        )
 
         if not download_success:
             logging.warning("Extended details download had issues, using basic descriptions")

--- a/tests/test_download_config.py
+++ b/tests/test_download_config.py
@@ -1,0 +1,40 @@
+"""dlworkers / dlthreshold resolution (auto, overrides, fallbacks)."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from gracenote2epg.config.base import ConfigManager
+
+
+def _cm(**settings):
+    cm = ConfigManager(Path(tempfile.mkdtemp()) / "gracenote2epg.xml")
+    cm.settings = settings
+    return cm
+
+
+class DownloadThresholdTests(unittest.TestCase):
+    def test_auto_resolves_to_the_waf_wall(self):
+        self.assertEqual(_cm(dlthreshold="auto").get_download_threshold(), 500)
+
+    def test_default_when_missing_is_auto(self):
+        self.assertEqual(_cm().get_download_threshold(), 500)
+
+    def test_positive_integer_overrides(self):
+        self.assertEqual(_cm(dlthreshold="250").get_download_threshold(), 250)
+
+    def test_zero_and_garbage_fall_back_to_auto(self):
+        self.assertEqual(_cm(dlthreshold="0").get_download_threshold(), 500)
+        self.assertEqual(_cm(dlthreshold="nope").get_download_threshold(), 500)
+
+
+class DownloadWorkersTests(unittest.TestCase):
+    def test_auto_and_overrides(self):
+        self.assertEqual(_cm(dlworkers="auto").get_download_workers(), 4)
+        self.assertEqual(_cm(dlworkers="2").get_download_workers(), 2)
+        self.assertEqual(_cm(dlworkers="99").get_download_workers(), 8)  # clamped
+        self.assertEqual(_cm(dlworkers="x").get_download_workers(), 4)  # fallback
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_worker_pool.py
+++ b/tests/test_worker_pool.py
@@ -178,5 +178,52 @@ class RetryTests(unittest.TestCase):
         self.assertEqual(pool.rate_limited, 4)
 
 
+class EarlyAbortTests(unittest.TestCase):
+    def test_pool_aborts_and_terminates_when_server_always_429s(self):
+        # A server stuck behind its WAF wall: every request is rate-limited.
+        def execute(session, task):
+            return DownloadResult(task.task_id, success=False, rate_limited=True)
+
+        pool = PacedWorkerPool(execute, workers=4, governor=instant_governor(), abort_after=10)
+        results = pool.run(tasks(500), max_attempts=2)
+
+        # It must STOP on its own (no endless crawl / requeue loop)...
+        self.assertTrue(pool.aborted)
+        # ...account every task exactly once so run() returns...
+        self.assertEqual(len(results), 500)
+        self.assertEqual({r.task_id for r in results}, {str(i) for i in range(500)})
+        self.assertTrue(all(not r.success for r in results))
+        # ...and it must have stopped EARLY rather than hammering all 500x2.
+        self.assertLess(pool.requests, 500)
+
+    def test_no_abort_when_disabled(self):
+        def execute(session, task):
+            return DownloadResult(task.task_id, success=False, rate_limited=True)
+
+        pool = PacedWorkerPool(execute, workers=2, governor=instant_governor(), abort_after=0)
+        results = pool.run(tasks(20), max_attempts=1)
+        self.assertFalse(pool.aborted)
+        self.assertEqual(len(results), 20)  # still terminates (bounded by max_attempts)
+
+
+class OnResultTests(unittest.TestCase):
+    def test_on_result_called_once_per_final_result(self):
+        seen = []
+        lock = threading.Lock()
+
+        def on_result(result):
+            with lock:
+                seen.append(result.task_id)
+
+        pool = PacedWorkerPool(
+            lambda s, t: DownloadResult(t.task_id, True),
+            workers=3,
+            governor=instant_governor(),
+            on_result=on_result,
+        )
+        pool.run(tasks(30))
+        self.assertEqual(sorted(seen, key=int), [str(i) for i in range(30)])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

A cold-cache rebuild (the user deleted 1000+ cached series to force re-downloads) hung at ~536/1345 with **no error**. `--debug` confirmed it: the run cruised at HTTP 200, then the Gracenote API hit its **cumulative-volume WAF wall (HTTP 429)** around ~500 requests and kept returning 429. The governor backed off to `min_rate`, failures were re-queued at `debug` level, and it **crawled silently** — looking frozen and needing a manual kill.

Key facts: concurrency reaches the wall sooner; a **single sequential connection is never blocked**; the retry-to-end is futile against a persistent wall (just adds load).

## Changes

- **`dlthreshold` setting** (schema **v8**, default `auto`≈500): when the number of series details to fetch reaches it, download **sequentially** (reliable) instead of via the parallel pool; below it, parallel as before. Configurable to an explicit integer.
- **Early abort (guaranteed termination):** the worker pool stops after N consecutive 429s instead of crawling, accounting the rest as failed so `run()` returns promptly. **The process always terminates on its own — no manual kill.** Leftover work is fetched next run.
- **Save-as-you-go:** each detail is persisted as it finalises (`on_result`), so an interrupted/aborted run keeps its progress (previously everything was saved only at the end of the batch and lost on kill).
- **Visibility:** per-attempt `debug` log of the series id, and 429/back-off now logged at **WARNING** (no more silence).

Wired through `config/{settings,base,validation}`, `parser/base`, `main`.

## Tests (105 total, green)

- `EarlyAbortTests`: a server that always 429s → pool aborts, **terminates**, accounts every task once, and stops *early* (no full hammering).
- `OnResultTests`: `on_result` fires once per final result (save-as-you-go).
- `DownloadThreshold/WorkersTests`: `auto`/override/fallback resolution.
- `black` + `flake8` clean. Config auto-migrates v5/v6/v7 → v8.

> Can't reproduce the real WAF locally — the pool/abort logic is unit-tested without network; the 429 behaviour is for **NAS validation**. Branched off `main` (currently dev6 with #14 merged); version → **dev7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
