### PR TITLE
downloader: adaptive concurrency wave + per-request jittered delay

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,14 +36,21 @@ with no change to the generated guide.
   non-critical series details), and the final stats report the pool's request
   counts accurately.
 - **Cold-cache rate-limit handling**: the Gracenote API blocks (HTTP 429) after
-  a few hundred requests, which concurrency reaches sooner. A new `dlthreshold`
-  setting (`auto`≈500) downloads large series-detail batches **sequentially**
-  (never rate-limited) while keeping the parallel pool for normal refreshes. As
-  a safety net, the parallel pool now **aborts early** if the server keeps
-  returning 429 (instead of crawling forever), logs blocks/back-offs at WARNING,
-  and **saves details as they arrive** — so an interrupted or aborted run keeps
-  its progress, the rest is fetched next run, and the process always terminates
-  on its own. Config schema → 8.
+  a few hundred requests, which concurrency reaches sooner. The new `dlthreshold`
+  setting controls the response:
+  - `auto` (default) = **adaptive concurrency**: the parallel pool rides the wall
+    like a wave — a 429 halves the in-flight workers (collapsing toward one) and
+    slows the shared rate governor, and a clean streak ramps both back up. Every
+    request also carries an adaptive, jittered delay (one worker or several) so
+    the stream looks organic, not metronomic.
+  - a number (e.g. `500`) = download large batches over a single **sequential**
+    connection (never rate-limited), parallel below the threshold.
+
+  Either way the pool **aborts early** if the server stays shut (instead of
+  crawling forever), logs blocks/back-offs at WARNING, and **saves details as
+  they arrive** — so an interrupted or aborted run keeps its progress, the rest
+  is fetched next run, and the process always terminates on its own. Config
+  schema → 8.
 
 ### Fixed
 - **Config backup retention**: timestamped configuration backups

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ gracenote2epg auto-detects your system and uses appropriate directories:
 
   <!-- Download performance -->
   <setting id="dlworkers">auto</setting>                       <!-- Parallel download workers: 1=sequential, 2-8=fixed, auto=recommended -->
-  <setting id="dlthreshold">auto</setting>                     <!-- Switch to sequential above N pending downloads (avoids 429 wall): auto(~500) or a number -->
+  <setting id="dlthreshold">auto</setting>                     <!-- auto=adaptive concurrency (parallel, rides out 429s); a number=go sequential above N pending downloads -->
 
   <!-- Image source host (first 'enabled' is used) -->
   <imagesources>
@@ -92,19 +92,25 @@ Parallel workers each reuse one persistent connection and share a combined-rate
 governor, so a refresh's new-series delta downloads ~3× faster without tripping
 the server. There is a single data host (no alternate source to configure).
 
-`dlthreshold` guards the cold-cache case. The Gracenote API enforces a
-cumulative-volume wall (HTTP 429) after a few hundred requests, which concurrency
-reaches sooner; a single sequential connection is never blocked. So when the
-number of series details to fetch reaches `dlthreshold`, the run downloads them
-sequentially (slower but reliable); below it, the parallel pool is used.
+`dlthreshold` decides how the cold-cache case is handled. The Gracenote API
+enforces a cumulative-volume wall (HTTP 429) after a few hundred requests, which
+concurrency reaches sooner; a single sequential connection is never blocked.
 
-- `auto` (default) — the observed wall, ~500.
-- a positive integer — an explicit batch size to switch at.
+- `auto` (default) — **adaptive concurrency**. The pool stays parallel and rides
+  the wall like a wave: on a 429 it halves the number of in-flight workers
+  (collapsing toward one) and the rate governor slows down; after a clean streak
+  it ramps both back up. Faster than sequential when the server tolerates short
+  bursts, and it self-tunes. Every request also carries an adaptive, jittered
+  delay (one worker or several), so the stream looks organic rather than
+  metronomic.
+- a positive integer (e.g. `500`) — when at least that many series details are
+  pending, download them over a **single sequential connection** (slower but the
+  WAF never blocks one connection); below it, parallel as usual.
 
-As a safety net, even in parallel mode the pool aborts early if the server keeps
-returning 429 (instead of crawling), and details are saved as they arrive, so a
-partial/aborted run keeps its progress and the rest is fetched on the next run —
-the process always terminates on its own.
+Either way the pool **aborts early** if the server stays shut (consecutive 429s
+that never recover), and details are **saved as they arrive**, so a partial or
+aborted run keeps its progress, the rest is fetched on the next run, and the
+process always terminates on its own.
 
 ## Image Source
 

--- a/gracenote2epg.xml
+++ b/gracenote2epg.xml
@@ -42,7 +42,7 @@
 
   <!-- Download performance -->
   <setting id="dlworkers">auto</setting>                       <!-- Parallel download workers: 1=sequential, 2-8=fixed, auto=recommended -->
-  <setting id="dlthreshold">auto</setting>                     <!-- Switch to sequential above N pending downloads (avoids 429 wall): auto(~500) or a number -->
+  <setting id="dlthreshold">auto</setting>                     <!-- auto=adaptive concurrency (parallel, rides out 429s); a number=go sequential above N pending downloads -->
 
   <!-- Image source host: the first 'enabled' source is used for program/cast   -->
   <!-- images. Mirrors serve the same images; switch by toggling status         -->

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev8"
+__version__ = "2.0.0-dev9"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/config/base.py
+++ b/gracenote2epg/config/base.py
@@ -117,29 +117,23 @@ class ConfigManager:
         except (TypeError, ValueError):
             return self.AUTO_DOWNLOAD_WORKERS
 
-    # Pending-download count above which series details switch to sequential.
-    # The Gracenote API WAF blocks (HTTP 429) after a few hundred requests, and
-    # the cumulative wall is reached around ~500; staying parallel only below it
-    # keeps the speed win for normal refreshes while a cold rebuild (a large
-    # batch) goes sequential, which the server never rate-limits.
-    AUTO_DOWNLOAD_THRESHOLD = 500
+    def get_download_threshold(self) -> Optional[int]:
+        """Batch size at/above which series details download sequentially.
 
-    def get_download_threshold(self) -> int:
-        """Parallel→sequential switch point from ``dlthreshold``.
-
-        When the number of series details to download is at or above this value,
-        the run uses a single sequential connection (which never trips the WAF);
-        below it, the parallel worker pool is used. ``auto`` (default) = ~the
-        observed WAF wall; a positive integer overrides it. ``0``/unknown → auto.
+        ``auto`` (default) returns ``None``: stay parallel and let the adaptive
+        concurrency limiter ride out 429s (collapse toward one worker, then ramp
+        back). A positive integer forces a single sequential connection once that
+        many details are pending (the WAF never blocks one connection).
+        ``0``/unknown → ``auto`` (None).
         """
         value = str(self.settings.get("dlthreshold", "auto")).strip().lower()
         if value == "auto":
-            return self.AUTO_DOWNLOAD_THRESHOLD
+            return None
         try:
             parsed = int(value)
-            return parsed if parsed > 0 else self.AUTO_DOWNLOAD_THRESHOLD
+            return parsed if parsed > 0 else None
         except (TypeError, ValueError):
-            return self.AUTO_DOWNLOAD_THRESHOLD
+            return None
 
     def _resolve_backup_retention(self, value) -> int:
         """Number of distinct config backups to keep from ``reconf``.

--- a/gracenote2epg/downloader/concurrency.py
+++ b/gracenote2epg/downloader/concurrency.py
@@ -1,0 +1,65 @@
+"""
+gracenote2epg.downloader.concurrency - adaptive concurrency limiter (AIMD)
+
+Complements the rate governor on a second axis: how MANY requests may be in
+flight at once. It starts at the worker count, halves on a rate-limit / WAF
+signal (collapsing toward a single worker), and ramps back up one slot at a time
+after a streak of clean requests — a "wave" that rides just under the server's
+concurrency tolerance. Workers acquire a slot before each request; the extras
+block until a slot frees or the limit grows again.
+
+Thread-safe via a single Condition. Fully synchronous and deterministic (no
+sleeping), so it is testable without real threads beyond the ones under test.
+"""
+
+import threading
+
+
+class ConcurrencyLimiter:
+    """AIMD limiter on the number of concurrently in-flight requests."""
+
+    def __init__(self, max_concurrency: int, *, success_threshold: int = 10):
+        self._max = max(1, max_concurrency)
+        self._limit = self._max
+        self._active = 0
+        self._successes = 0
+        self._success_threshold = max(1, success_threshold)
+        self._cond = threading.Condition()
+
+    @property
+    def limit(self) -> int:
+        with self._cond:
+            return self._limit
+
+    @property
+    def max_concurrency(self) -> int:
+        return self._max
+
+    def acquire(self) -> None:
+        """Block until an in-flight slot is available, then take it."""
+        with self._cond:
+            while self._active >= self._limit:
+                self._cond.wait()
+            self._active += 1
+
+    def release(self) -> None:
+        """Return a slot and wake a waiter."""
+        with self._cond:
+            self._active -= 1
+            self._cond.notify_all()
+
+    def on_rate_limited(self) -> None:
+        """Multiplicative decrease: collapse the in-flight ceiling toward 1."""
+        with self._cond:
+            self._successes = 0
+            self._limit = max(1, self._limit // 2)
+            # Ceiling lowered: current holders drain naturally; nothing to wake.
+
+    def on_success(self) -> None:
+        """Additive increase: re-open one slot after a clean streak."""
+        with self._cond:
+            self._successes += 1
+            if self._successes >= self._success_threshold and self._limit < self._max:
+                self._successes = 0
+                self._limit += 1
+                self._cond.notify_all()

--- a/gracenote2epg/downloader/pacing.py
+++ b/gracenote2epg/downloader/pacing.py
@@ -9,12 +9,17 @@ not peak throughput.
 ``RateController`` implements TCP-style AIMD on the request rate: additive
 increase while requests succeed, multiplicative decrease on a rate-limit / WAF
 signal. It converges to a sawtooth just below the server's ceiling and stays
-there. See docs/parallel-download-redesign.md.
+there. A per-request *jitter* spreads the spacing so the combined stream looks
+organic rather than metronomic. The controller is thread-safe (the worker pool
+shares one) and reserves each slot under a short lock, then sleeps *outside* it
+so workers genuinely overlap. See docs/parallel-download-redesign.md.
 
-The clock and sleep functions are injectable so the controller is fully
-testable without real time.
+The clock, sleep and rng functions are injectable so the controller is fully
+testable without real time or randomness.
 """
 
+import random
+import threading
 import time
 from typing import Callable, Optional
 
@@ -32,8 +37,10 @@ class RateController:
         decrease_factor: float = 0.5,
         success_threshold: int = 10,
         waf_cooldown: float = 20.0,
+        jitter: float = 0.0,
         clock: Callable[[], float] = time.monotonic,
         sleep: Callable[[float], None] = time.sleep,
+        rng: Callable[[], float] = random.random,
     ):
         if not (0 < min_rate <= max_rate):
             raise ValueError("require 0 < min_rate <= max_rate")
@@ -43,48 +50,62 @@ class RateController:
         self._decrease_factor = decrease_factor
         self._success_threshold = max(1, success_threshold)
         self._waf_cooldown = waf_cooldown
+        # Fraction (0..1) by which each gap is randomly stretched/shrunk.
+        self._jitter = max(0.0, min(1.0, jitter))
         self._clock = clock
         self._sleep = sleep
+        self._rng = rng
 
+        self._lock = threading.Lock()
         self.rate = self._clamp(initial_rate)
         self._successes = 0
-        self._last_request: Optional[float] = None
+        self._next_allowed: Optional[float] = None
 
     def _clamp(self, rate: float) -> float:
         return max(self._min_rate, min(self._max_rate, rate))
 
     @property
     def interval(self) -> float:
-        """Current minimum delay between requests, in seconds."""
+        """Current mean delay between requests, in seconds."""
         return 1.0 / self.rate
 
     def wait(self) -> float:
-        """Block until the next request is allowed; returns the slept duration."""
-        slept = 0.0
-        now = self._clock()
-        if self._last_request is not None:
-            gap = self.interval - (now - self._last_request)
-            if gap > 0:
-                self._sleep(gap)
-                slept = gap
-        self._last_request = self._clock()
-        return slept
+        """Block until the next request is allowed; returns the slept duration.
+
+        Reserves the next slot under the lock (so the *combined* rate across
+        workers is governed), jittering the gap, then sleeps outside the lock so
+        workers overlap.
+        """
+        with self._lock:
+            now = self._clock()
+            gap = 1.0 / self.rate
+            if self._jitter:
+                gap *= 1.0 + (self._rng() * 2.0 - 1.0) * self._jitter
+            start = now if self._next_allowed is None else max(now, self._next_allowed)
+            self._next_allowed = start + gap
+            sleep_for = start - now
+        if sleep_for > 0:
+            self._sleep(sleep_for)
+        return sleep_for
 
     def on_success(self) -> None:
         """Additive increase: speed up after a streak of clean requests."""
-        self._successes += 1
-        if self._successes >= self._success_threshold:
-            self._successes = 0
-            self.rate = self._clamp(self.rate + self._increase_step)
+        with self._lock:
+            self._successes += 1
+            if self._successes >= self._success_threshold:
+                self._successes = 0
+                self.rate = self._clamp(self.rate + self._increase_step)
 
     def on_rate_limited(self) -> None:
         """Multiplicative decrease: back off on a 429 / Too Many Requests."""
-        self._successes = 0
-        self.rate = self._clamp(self.rate * self._decrease_factor)
+        with self._lock:
+            self._successes = 0
+            self.rate = self._clamp(self.rate * self._decrease_factor)
 
     def on_waf_block(self) -> None:
         """A hard block: back off and pause for a cooldown before resuming."""
         self.on_rate_limited()
         if self._waf_cooldown > 0:
             self._sleep(self._waf_cooldown)
-            self._last_request = self._clock()
+            with self._lock:
+                self._next_allowed = self._clock()

--- a/gracenote2epg/downloader/series.py
+++ b/gracenote2epg/downloader/series.py
@@ -29,7 +29,7 @@ class SeriesDownloader(DownloaderStatsMixin):
         self.cached_series: Set[str] = set()
 
     def download_series_details(
-        self, series_list: List[str], workers: int = 1, threshold: int = 0
+        self, series_list: List[str], workers: int = 1, threshold: Optional[int] = None
     ) -> bool:
         """
         Download extended details for series with intelligent caching
@@ -64,10 +64,11 @@ class SeriesDownloader(DownloaderStatsMixin):
             workers,
         )
 
-        # Large cold-cache batches trip the Gracenote rate-limit wall (HTTP 429)
-        # under concurrency; the server never blocks a single sequential
-        # connection, so switch to it above the configured threshold.
-        if workers > 1 and threshold and len(to_download) >= threshold:
+        # With an explicit dlthreshold, large cold-cache batches download
+        # sequentially (the WAF never blocks a single connection). With
+        # dlthreshold=auto (threshold is None) we stay parallel and let the
+        # adaptive concurrency limiter ride out any 429s instead.
+        if workers > 1 and threshold is not None and len(to_download) >= threshold:
             logging.warning(
                 "Large batch (%d ≥ dlthreshold %d): downloading sequentially to avoid the "
                 "Gracenote rate-limit wall (HTTP 429); this is slower but reliable.",

--- a/gracenote2epg/downloader/worker_pool.py
+++ b/gracenote2epg/downloader/worker_pool.py
@@ -3,16 +3,22 @@ gracenote2epg.downloader.worker_pool - bounded keep-alive worker pool
 
 A small, fixed pool of long-lived workers, each owning ONE persistent connection
 (its own session) and pulling tasks from a shared queue, so each worker
-downloads its share serially over a reused connection. A single shared
-``RateController`` (AIMD) caps the *combined* request rate and backs off globally
-on a rate-limit / WAF signal — a safety backstop that stays out of the way on
-normal small refreshes. See docs/parallel-download-redesign.md.
+downloads its share serially over a reused connection.
 
-If the server keeps returning HTTP 429 (its cumulative-volume wall), the pool
-gives up early instead of crawling forever: after a run of consecutive
-rate-limited responses it aborts the remaining queue (accounting those items as
-failed) so the process always terminates without a manual kill. The leftover
-work is simply picked up on the next run.
+Two adaptive controls ride on top, both reacting to the server's HTTP 429 / WAF
+signal:
+
+* a shared **rate** governor (AIMD on requests/second, with per-request jitter)
+  so the combined stream stays under the server's sustainable rate and looks
+  organic rather than metronomic — the "adaptive delay" applied on every
+  request, with one worker or several;
+* an adaptive **concurrency** limiter (AIMD on how many requests are in flight)
+  that collapses toward a single worker on a 429 and ramps back up after a clean
+  streak — a "wave" that finds the server's concurrency tolerance.
+
+If the server keeps returning 429, the pool gives up early (accounting the rest
+as failed) so the process always terminates without a manual kill; the leftover
+work is picked up on the next run.
 
 The session factory and the per-task execute function are injected, so the pool
 is fully testable without any network.
@@ -23,6 +29,7 @@ import queue
 import threading
 from typing import Callable, List, Optional
 
+from .concurrency import ConcurrencyLimiter
 from .pacing import RateController
 from .tasks import DownloadResult, DownloadTask
 
@@ -44,14 +51,16 @@ class PacedWorkerPool:
         governor: Optional[RateController] = None,
         on_progress: Optional[ProgressFn] = None,
         on_result: Optional[ResultFn] = None,
-        abort_after: int = 12,
+        abort_after: int = 40,
+        adaptive_concurrency: bool = True,
     ):
         self._execute = execute
         self._workers = max(1, workers)
         self._session_factory = session_factory or (lambda: None)
-        # Self-regulating governor: starts moderate (safe even on a cold run of
-        # hundreds of new series), ramps up via AIMD while the server is happy,
-        # and backs off on a 429/WAF signal.
+        # Self-regulating rate governor: starts moderate (safe even on a cold run
+        # of hundreds of new series), ramps up via AIMD while the server is
+        # happy, backs off on a 429/WAF signal, and jitters each gap so the
+        # stream looks organic.
         self._governor = governor or RateController(
             initial_rate=5.0,
             max_rate=20.0,
@@ -59,14 +68,17 @@ class PacedWorkerPool:
             increase_step=0.5,
             success_threshold=10,
             decrease_factor=0.5,
+            jitter=0.35,
         )
+        # Adaptive concurrency: collapse the in-flight count on 429, ramp back on
+        # success. Disabled -> all workers always active (fixed concurrency).
+        self._limiter = ConcurrencyLimiter(self._workers) if adaptive_concurrency else None
         self._on_progress = on_progress
         self._on_result = on_result
         # Stop hitting the server after this many consecutive rate-limited
-        # responses (0 = never abort). Guards against an endless crawl when the
-        # WAF wall stays shut.
+        # responses (0 = never abort). A normal "wave" intersperses successes
+        # that reset the counter, so only a persistently shut wall trips it.
         self._abort_after = abort_after
-        self._gov_lock = threading.Lock()
         self._stats_lock = threading.Lock()
         self._abort = threading.Event()
         # Aggregate request stats (one entry per attempt), for reporting.
@@ -82,14 +94,17 @@ class PacedWorkerPool:
     def aborted(self) -> bool:
         return self._abort.is_set()
 
+    @property
+    def concurrency_limit(self) -> int:
+        return self._limiter.limit if self._limiter else self._workers
+
     def run(self, tasks: List[DownloadTask], max_attempts: int = 1) -> List[DownloadResult]:
         """Execute *tasks*; returns their final results (order not guaranteed).
 
         Failed tasks (including rate-limited ones) are re-queued at the **end**
-        and retried up to ``max_attempts`` total, so a transient/blocked request
-        is given another chance after the rest of the batch (and after the
-        governor has backed off). If the server keeps rate-limiting, the pool
-        aborts early (see module docstring) rather than looping.
+        and retried up to ``max_attempts`` total. If the server keeps
+        rate-limiting, the pool aborts early (see module docstring) rather than
+        looping.
         """
         if not tasks:
             return []
@@ -131,7 +146,7 @@ class PacedWorkerPool:
                     # so the pool finishes promptly instead of crawling.
                     sink.add(DownloadResult(task.task_id, success=False, error="aborted"))
                     continue
-                result = self._process(session, task)
+                result = self._process_gated(session, task)
                 if not result.success and attempt < max_attempts and not self._abort.is_set():
                     logging.debug("Requeue %s (attempt %d/%d)", task.task_id, attempt, max_attempts)
                     work.put((task, attempt + 1))
@@ -142,21 +157,36 @@ class PacedWorkerPool:
             if callable(close):
                 close()
 
+    def _process_gated(self, session, task: DownloadTask) -> DownloadResult:
+        """Acquire an in-flight slot (adaptive concurrency), then process."""
+        if self._limiter is not None:
+            self._limiter.acquire()
+        try:
+            result = self._process(session, task)
+        finally:
+            if self._limiter is not None:
+                self._limiter.release()
+        # Feed the concurrency wave after releasing the slot.
+        if self._limiter is not None:
+            if result.rate_limited:
+                self._limiter.on_rate_limited()
+            elif result.success:
+                self._limiter.on_success()
+        return result
+
     def _process(self, session, task: DownloadTask) -> DownloadResult:
-        """Pace (governed combined rate), run one request, feed the governor."""
-        with self._gov_lock:
-            self._governor.wait()
-        logging.debug("Downloading %s", task.task_id)
+        """Pace (governed jittered rate), run one request, feed the governor."""
+        slept = self._governor.wait()
+        logging.debug("  Adaptive delay: %.2fs (rate %.1f/s)", slept, self._governor.rate)
         try:
             result = self._execute(session, task)
         except Exception as e:  # never let one task kill a worker
             logging.debug("Task %s raised: %s", task.task_id, e)
             result = DownloadResult(task.task_id, success=False, error=str(e))
-        with self._gov_lock:
-            if result.rate_limited:
-                self._governor.on_rate_limited()
-            elif result.success:
-                self._governor.on_success()
+        if result.rate_limited:
+            self._governor.on_rate_limited()
+        elif result.success:
+            self._governor.on_success()
         self._record(result)
         return result
 

--- a/gracenote2epg/parser/base.py
+++ b/gracenote2epg/parser/base.py
@@ -7,7 +7,7 @@ The DataParser now acts as a pure orchestrator that coordinates between:
 """
 
 import logging
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from ..downloader import OptimizedDownloader, GuideDownloader, SeriesDownloader
 from .guide import GuideParser
@@ -70,7 +70,9 @@ class DataParser:
 
         return download_success
 
-    def download_and_parse_series_details(self, workers: int = 1, threshold: int = 0) -> bool:
+    def download_and_parse_series_details(
+        self, workers: int = 1, threshold: Optional[int] = None
+    ) -> bool:
         """Download and parse extended series details with separated logic"""
         # Extract active series list from parsed schedule
         series_list = self.get_active_series_list()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -23,8 +23,8 @@ class ConcurrencyLimiterTests(unittest.TestCase):
 
     def test_ramps_back_up_after_success_streak(self):
         c = ConcurrencyLimiter(4, success_threshold=3)
-        c.on_rate_limited()  # 4 -> 2
-        c.on_rate_limited()  # 2 -> 1
+        c.on_rate_limited()  # halve to two
+        c.on_rate_limited()  # halve to one
         self.assertEqual(c.limit, 1)
         for _ in range(3):
             c.on_success()
@@ -43,7 +43,7 @@ class ConcurrencyLimiterTests(unittest.TestCase):
         # With limit collapsed to 1, only one acquire succeeds until a release.
         c = ConcurrencyLimiter(4)
         c.on_rate_limited()
-        c.on_rate_limited()  # limit = 1
+        c.on_rate_limited()  # collapsed to a single in-flight slot
         c.acquire()
 
         got = threading.Event()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,65 @@
+"""Tests for the adaptive ConcurrencyLimiter (the 'wave')."""
+
+import threading
+import unittest
+
+from gracenote2epg.downloader.concurrency import ConcurrencyLimiter
+
+
+class ConcurrencyLimiterTests(unittest.TestCase):
+    def test_starts_at_max(self):
+        self.assertEqual(ConcurrencyLimiter(4).limit, 4)
+
+    def test_collapses_toward_one_on_rate_limit(self):
+        c = ConcurrencyLimiter(8)
+        c.on_rate_limited()
+        self.assertEqual(c.limit, 4)
+        c.on_rate_limited()
+        self.assertEqual(c.limit, 2)
+        c.on_rate_limited()
+        self.assertEqual(c.limit, 1)
+        c.on_rate_limited()
+        self.assertEqual(c.limit, 1)  # floor at 1
+
+    def test_ramps_back_up_after_success_streak(self):
+        c = ConcurrencyLimiter(4, success_threshold=3)
+        c.on_rate_limited()  # 4 -> 2
+        c.on_rate_limited()  # 2 -> 1
+        self.assertEqual(c.limit, 1)
+        for _ in range(3):
+            c.on_success()
+        self.assertEqual(c.limit, 2)  # one slot re-opened
+        for _ in range(3):
+            c.on_success()
+        self.assertEqual(c.limit, 3)
+
+    def test_does_not_exceed_max(self):
+        c = ConcurrencyLimiter(2, success_threshold=1)
+        for _ in range(20):
+            c.on_success()
+        self.assertEqual(c.limit, 2)
+
+    def test_acquire_release_bounds_inflight(self):
+        # With limit collapsed to 1, only one acquire succeeds until a release.
+        c = ConcurrencyLimiter(4)
+        c.on_rate_limited()
+        c.on_rate_limited()  # limit = 1
+        c.acquire()
+
+        got = threading.Event()
+
+        def second():
+            c.acquire()  # must block until the first releases
+            got.set()
+            c.release()
+
+        t = threading.Thread(target=second, daemon=True)
+        t.start()
+        self.assertFalse(got.wait(0.2))  # still blocked
+        c.release()  # frees the single slot
+        self.assertTrue(got.wait(1.0))  # now it proceeds
+        t.join(1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_download_config.py
+++ b/tests/test_download_config.py
@@ -14,18 +14,19 @@ def _cm(**settings):
 
 
 class DownloadThresholdTests(unittest.TestCase):
-    def test_auto_resolves_to_the_waf_wall(self):
-        self.assertEqual(_cm(dlthreshold="auto").get_download_threshold(), 500)
+    def test_auto_means_no_cutoff_adaptive(self):
+        # auto -> None: stay parallel, adaptive concurrency handles 429s.
+        self.assertIsNone(_cm(dlthreshold="auto").get_download_threshold())
 
     def test_default_when_missing_is_auto(self):
-        self.assertEqual(_cm().get_download_threshold(), 500)
+        self.assertIsNone(_cm().get_download_threshold())
 
     def test_positive_integer_overrides(self):
         self.assertEqual(_cm(dlthreshold="250").get_download_threshold(), 250)
 
     def test_zero_and_garbage_fall_back_to_auto(self):
-        self.assertEqual(_cm(dlthreshold="0").get_download_threshold(), 500)
-        self.assertEqual(_cm(dlthreshold="nope").get_download_threshold(), 500)
+        self.assertIsNone(_cm(dlthreshold="0").get_download_threshold())
+        self.assertIsNone(_cm(dlthreshold="nope").get_download_threshold())
 
 
 class DownloadWorkersTests(unittest.TestCase):

--- a/tests/test_pacing.py
+++ b/tests/test_pacing.py
@@ -68,6 +68,22 @@ class RateControllerPacingTests(unittest.TestCase):
         rc.wait()
         self.assertAlmostEqual(t.slept[-1], 0.5, places=6)
 
+    def test_jitter_varies_the_gap(self):
+        t = FakeTime()
+        rng = iter([0.0, 1.0, 0.5])  # min, max, mid jitter factors
+        rc = RateController(
+            initial_rate=2.0,  # mean interval 0.5s
+            jitter=0.5,
+            clock=t.clock,
+            sleep=t.sleep,
+            rng=lambda: next(rng),
+        )
+        rc.wait()  # reserves a short gap (rng=0.0 -> factor 0.5 -> 0.25s)
+        rc.wait()  # sleeps that 0.25s, reserves a long gap (rng=1.0 -> 0.75s)
+        rc.wait()  # sleeps the 0.75s
+        self.assertAlmostEqual(t.slept[0], 0.25, places=6)
+        self.assertAlmostEqual(t.slept[1], 0.75, places=6)
+
     def test_wait_accounts_for_elapsed_time(self):
         t = FakeTime()
         rc = RateController(initial_rate=2.0, clock=t.clock, sleep=t.sleep)  # interval 0.5

--- a/tests/test_worker_pool.py
+++ b/tests/test_worker_pool.py
@@ -206,6 +206,46 @@ class EarlyAbortTests(unittest.TestCase):
         self.assertEqual(len(results), 20)  # still terminates (bounded by max_attempts)
 
 
+class AdaptiveConcurrencyTests(unittest.TestCase):
+    def test_concurrency_collapses_under_429_then_completes(self):
+        # Server rate-limits the first 30 requests, then is happy.
+        state = {"n": 0}
+        lock = threading.Lock()
+        limits = []
+
+        def execute(session, task):
+            with lock:
+                state["n"] += 1
+                limited = state["n"] <= 30
+            limits.append(pool.concurrency_limit)
+            return DownloadResult(task.task_id, success=not limited, rate_limited=limited)
+
+        # abort disabled so the early-stop doesn't pre-empt the wave.
+        pool = PacedWorkerPool(execute, workers=8, governor=instant_governor(), abort_after=0)
+        results = pool.run(tasks(120), max_attempts=1)
+
+        self.assertEqual(len(results), 120)  # all accounted, no deadlock
+        self.assertLess(min(limits), 8)  # the in-flight ceiling collapsed
+        self.assertEqual(min(limits), 1)  # all the way down to a single worker
+
+    def test_disabling_adaptive_concurrency_keeps_full_width(self):
+        seen = []
+
+        def execute(session, task):
+            seen.append(pool.concurrency_limit)
+            return DownloadResult(task.task_id, success=False, rate_limited=True)
+
+        pool = PacedWorkerPool(
+            execute,
+            workers=4,
+            governor=instant_governor(),
+            abort_after=0,
+            adaptive_concurrency=False,
+        )
+        pool.run(tasks(20), max_attempts=1)
+        self.assertTrue(all(limit == 4 for limit in seen))  # never collapses
+
+
 class OnResultTests(unittest.TestCase):
     def test_on_result_called_once_per_final_result(self):
         seen = []


### PR DESCRIPTION
## Idea (your request)

Independently of the static 500 cutoff: keep **all workers active**, and on a 429 **collapse toward a single worker**, stay adaptive, then **re-activate workers** as things recover — *comme une vague*. Plus keep an **adaptive jittered delay on every worker** (1 or N) so the request pattern looks organic, like the sequential engine's `Adaptive delay: X.XXs`.

## What this does

`dlthreshold` now selects the strategy:

- **`auto` (default) → adaptive concurrency.** The parallel pool rides the wall like a wave:
  - HTTP 429 → halve the in-flight worker count (collapse toward 1) **and** the shared rate governor backs off;
  - clean streak → ramp both back up.
  - Every request carries an **adaptive, jittered delay** (one worker or several), logged as `Adaptive delay: X.XXs (rate Y/s)` — organic, not metronomic.
- **`<number>` (e.g. `500`) → sequential** above that many pending details (the WAF never blocks a single connection); parallel below.

Your empirical point baked in: sequential hit the wall ~4× and the rate AIMD recovered each time. With the wave, N workers reach the same walls faster and recover the same way — *même résultat, plus rapide* — and it's safe to test because the guards below guarantee termination.

## Safety (always terminates, no manual kill)

- **Early-abort** if the server stays shut (consecutive 429s with no recovery). A normal wave intersperses successes that reset the counter, so it won't trip prematurely.
- **Save-as-you-go**: details are persisted as they arrive; an interrupted/aborted run keeps its progress and the rest is fetched next run.
- Even without abort, `max_attempts` bounds the work, so `run()` always returns.

## Implementation

- `pacing.py` — `RateController` is now thread-safe and reserves each slot under a short lock then **sleeps outside it** (real parallel overlap), with injectable **per-request jitter**.
- `concurrency.py` — new `ConcurrencyLimiter` (AIMD on in-flight count; collapse on 429, ramp on success).
- `worker_pool.py` — gate each request through the limiter, feed both controllers, log the adaptive delay; dropped the old pacing lock.
- `config/base.py` — `dlthreshold=auto` → `None` (adaptive); a number keeps the sequential cutoff. No new setting, schema unchanged (v9).

## Tests (121 total, green)

- `test_concurrency.py` — collapse toward 1, ramp back, bounds in-flight, **no deadlock** under a collapsed limit.
- `test_pacing.py` — jitter varies the gap (default jitter 0 keeps existing timing tests deterministic).
- `test_worker_pool.py` — wave collapses under 429 then **completes** all tasks; `adaptive_concurrency=False` keeps full width.
- `test_download_config.py` — `dlthreshold=auto → None`.
- `black` + `flake8` clean.

## To try on the NAS (A/B)

- `dlthreshold=auto` → the wave (faster, self-tuning) — watch the `Adaptive delay` / WARNING lines and whether a concurrent burst provokes a harder block.
- `dlthreshold=500` → the proven sequential path on big batches.

Branched off `main` (dev8); version → **dev9**. Descoped nothing this time — the pacing-lock fix is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
