### PR TITLE
downloader: preserve xmltv on empty guide + clearer progress/retention logging

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -53,6 +53,11 @@ with no change to the generated guide.
   schema → 8.
 
 ### Fixed
+- **Never overwrite a good guide with an empty one**: if the guide download
+  returns no programmes at all (e.g. the server rate-limits every block), the
+  run now keeps the existing `xmltv.xml` and exits with an error instead of
+  regenerating an empty guide over it. The next run rebuilds it once the server
+  recovers.
 - **Config backup retention**: timestamped configuration backups
   (`gracenote2epg.xml.backup.*`) were never cleaned up and accumulated
   indefinitely (hundreds of files), many byte-for-byte identical. A new backup

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -75,6 +75,12 @@ with no change to the generated guide.
 - **`--basedir`**: now honoured for the config, cache, log and XMLTV locations.
 
 ### Changed
+- **Download/retention logging**: parallel downloads now trace each item with
+  its id and an `x/y` counter (e.g. `Extended details: SH… (377/1347)`,
+  `Guide block: …`), the per-request adaptive delay names the item it paces, the
+  unified retention summary now includes config backups (`reconf`), and the log
+  rotation period trace reads clearly (`current period, still in progress`
+  instead of `Complete: False`).
 - **Startup logging**: the active config, cache, log and XMLTV paths are now
   shown at startup (log and `--console`).
 - **Internal structure**: `xmltv.py` (947 lines) and `logrotate.py` (657 lines)

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev9"
+__version__ = "2.0.0-dev10"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/config/retention.py
+++ b/gracenote2epg/config/retention.py
@@ -40,6 +40,17 @@ class RetentionManager:
             settings.get("rexmltv", "7"), "daily"  # XMLTV backups are always daily
         )
 
+        # Config backups (reconf) are a COUNT of distinct versions, not days,
+        # because they are change-triggered rather than periodic. 0 = unlimited.
+        reconf = str(settings.get("reconf", "10")).strip().lower()
+        if reconf in ("unlimited", "0"):
+            config_backup_retention = 0
+        else:
+            try:
+                config_backup_retention = max(0, int(reconf))
+            except ValueError:
+                config_backup_retention = 10
+
         return {
             # Log rotation configuration
             "enabled": rotation_enabled,
@@ -48,10 +59,12 @@ class RetentionManager:
             # Extended retention information
             "log_retention_days": log_retention_days,
             "xmltv_retention_days": xmltv_retention_days,
+            "config_backup_retention": config_backup_retention,  # count, 0=unlimited
             # Original settings for logging
             "logrotate_setting": settings.get("logrotate", "true"),
             "relogs_setting": settings.get("relogs", "30"),
             "rexmltv_setting": settings.get("rexmltv", "7"),
+            "reconf_setting": settings.get("reconf", "10"),
         }
 
     def _parse_retention_to_days(self, retention_value: str, interval: str) -> int:

--- a/gracenote2epg/downloader/guide.py
+++ b/gracenote2epg/downloader/guide.py
@@ -127,24 +127,41 @@ class GuideDownloader(DownloaderStatsMixin):
         if not tasks:
             return
 
+        import threading
+
         existed_map = dict(to_fetch)
-        pool = PacedWorkerPool(execute, workers=workers, session_factory=make_session)
-        # Guide blocks are important: retry failed ones (re-queued at the end).
-        for result in pool.run(tasks, max_attempts=3):
+        total = len(tasks)
+        tally_lock = threading.Lock()
+
+        def on_result(result) -> None:
+            # Runs as each block finalises (save-as-you-go).
             saved = False
             if result.success and result.content:
                 saved = self.cache_manager.validate_and_save_guide_block(
                     result.content, result.task_id
                 )
-            if saved:
-                self.downloaded_count += 1
-            elif existed_map.get(result.task_id):
-                # Refresh failed but the previous version is still on disk.
-                self.cached_count += 1
-            else:
-                self.failed_count += 1
+            with tally_lock:
+                if saved:
+                    self.downloaded_count += 1
+                    note = ""
+                elif existed_map.get(result.task_id):
+                    # Refresh failed but the previous version is still on disk.
+                    self.cached_count += 1
+                    note = " [kept cached]"
+                else:
+                    self.failed_count += 1
+                    note = " [failed]"
+                idx = self.downloaded_count + self.cached_count + self.failed_count
+            logging.debug("  Guide block: %s (%d/%d)%s", result.task_id, idx, total, note)
+
+        pool = PacedWorkerPool(
+            execute, workers=workers, session_factory=make_session, on_result=on_result
+        )
+        # Guide blocks are important: retry failed ones (re-queued at the end).
+        pool.run(tasks, max_attempts=3)
 
         self.http_requests = pool.requests
+        self.rate_limited = pool.rate_limited
         self.rate_limited = pool.rate_limited
 
     def _download_single_block(

--- a/gracenote2epg/downloader/series.py
+++ b/gracenote2epg/downloader/series.py
@@ -119,12 +119,8 @@ class SeriesDownloader(DownloaderStatsMixin):
         total = len(to_download)
         tally_lock = threading.Lock()
 
-        def on_progress(done: int, _total: int):
-            if done == 1 or done % max(1, total // 10) == 0 or done == total:
-                logging.info("  Extended details: %d/%d", done, total)
-
         def on_result(result) -> None:
-            # Runs in worker threads as each download finalises.
+            # Runs in worker threads as each download finalises (save-as-you-go).
             saved = False
             if result.success and result.content:
                 try:
@@ -138,6 +134,17 @@ class SeriesDownloader(DownloaderStatsMixin):
                 else:
                     self.failed_count += 1
                     self.failed_series.append(result.task_id)
+                idx = self.downloaded_count + self.failed_count  # completed so far
+            # Per-item trace (parallel completes out of order) + periodic summary.
+            logging.debug(
+                "  Extended details: %s (%d/%d)%s",
+                result.task_id,
+                idx,
+                total,
+                "" if saved else " [failed]",
+            )
+            if idx == 1 or idx % max(1, total // 10) == 0 or idx == total:
+                logging.info("  Extended details: %d/%d", idx, total)
 
         tasks = [
             DownloadTask(
@@ -153,7 +160,6 @@ class SeriesDownloader(DownloaderStatsMixin):
             execute,
             workers=workers,
             session_factory=make_session,
-            on_progress=on_progress,
             on_result=on_result,
         )
         # Series details are non-critical: one best-effort retry (re-queued at

--- a/gracenote2epg/downloader/worker_pool.py
+++ b/gracenote2epg/downloader/worker_pool.py
@@ -177,7 +177,12 @@ class PacedWorkerPool:
     def _process(self, session, task: DownloadTask) -> DownloadResult:
         """Pace (governed jittered rate), run one request, feed the governor."""
         slept = self._governor.wait()
-        logging.debug("  Adaptive delay: %.2fs (rate %.1f/s)", slept, self._governor.rate)
+        logging.debug(
+            "  Downloading %s (adaptive delay %.2fs, rate %.1f/s)",
+            task.task_id,
+            slept,
+            self._governor.rate,
+        )
         try:
             result = self._execute(session, task)
         except Exception as e:  # never let one task kill a worker

--- a/gracenote2epg/logrotate/handler.py
+++ b/gracenote2epg/logrotate/handler.py
@@ -167,13 +167,15 @@ class CopyTruncateTimedRotatingFileHandler(logging.handlers.BaseRotatingHandler)
                                 "last_line": line_num,
                             }
 
+                            span = period_start.strftime("%Y-%m-%d")
+                            if period_end != period_start:
+                                span += " to " + period_end.strftime("%Y-%m-%d")
                             logging.debug(
-                                "Found %s %s (%s to %s) - Complete: %s",
+                                "Found %s log period %s (%s) - %s",
                                 self.period_name,
                                 period_suffix,
-                                period_start.strftime("%Y-%m-%d"),
-                                period_end.strftime("%Y-%m-%d"),
-                                is_complete,
+                                span,
+                                "complete" if is_complete else "current period, still in progress",
                             )
 
                         # Add line to this period

--- a/gracenote2epg/main.py
+++ b/gracenote2epg/main.py
@@ -139,6 +139,11 @@ def setup_logging(logging_config: dict, log_file: Path, retention_config: dict):
             log_retention,
         )
         logging.debug("  XMLTV backups: %d days retention", xmltv_retention)
+        config_backups = retention_config.get("config_backup_retention", 10)
+        logging.debug(
+            "  Config backups: %s",
+            "unlimited" if config_backups == 0 else "%d kept" % config_backups,
+        )
         logging.debug(
             "  Current log size: %d bytes, backup files: %d",
             rotation_status.get("current_log_size", 0),

--- a/gracenote2epg/main.py
+++ b/gracenote2epg/main.py
@@ -371,8 +371,28 @@ def main():
             xmltv_generator = XmltvGenerator(
                 cache_manager, image_base_url=config_manager.get_image_source()
             )
+            schedule = data_parser.get_schedule()
+
+            # Safety: if the guide produced no programmes at all (e.g. the server
+            # rate-limited every block), do NOT overwrite a previously good
+            # xmltv.xml with an empty guide. Leave it untouched and fail — the
+            # next run (after the WAF window resets) will rebuild it.
+            episode_count = sum(
+                1
+                for station_data in schedule.values()
+                for key in station_data
+                if not key.startswith("ch")
+            )
+            if episode_count == 0:
+                logging.error(
+                    "No guide data available (guide download failed or returned nothing); "
+                    "keeping the existing xmltv.xml rather than overwriting it with an empty "
+                    "guide. Will retry on the next run."
+                )
+                return 1
+
             xmltv_success = xmltv_generator.generate_xmltv(
-                schedule=data_parser.get_schedule(), config=config, xmltv_file=xmltv_file
+                schedule=schedule, config=config, xmltv_file=xmltv_file
             )
 
             if not xmltv_success:


### PR DESCRIPTION
Refinements found while testing the merged adaptive-concurrency run (#19) on a cold cache.

## Safety fix (important)

**Never overwrite a good guide with an empty one.** When the server rate-limits *every* guide block (a cold cache after repeated runs trips the WAF into a sustained 429 block), the run used to regenerate a 167-byte empty `xmltv.xml` over the previous good guide. It now counts parsed episodes and, if **zero**, keeps the existing file and exits 1 — the next run rebuilds it once the WAF window resets.

## Logging / visibility

- **Parallel downloads now trace each item** with its id and an `x/y` counter (parallel completes out of order), via a real-time `on_result` callback — which also brings **save-as-you-go to guide blocks** (previously saved only after the whole batch):
  - `Extended details: SH04501949 (377/1347)`
  - `Guide block: 2026061612.json.gz (5/112)`
- **Per-request adaptive-delay line names the item**: `Downloading SH… (adaptive delay 0.43s, rate 8.0/s)` (series IDs live in the POST body, so the bare requests-lib line didn't show them; guide GET URLs already did).
- **Unified retention summary** now includes config backups: `Config backups: 10 kept` (the `reconf` setting).
- **Log-rotation period trace** reads clearly: `current period, still in progress` instead of `Complete: False`, and drops the redundant `X to X` span for daily periods.

## Notes

- The guide already uses the same adaptive multi-worker pool (wave + governor + jitter); the cold-cache failure was the server hard-blocking, not a missing feature.
- 121 tests green, `black` + `flake8` clean. Branched off `main` (dev9); version → **dev10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
