### PR TITLE
downloader: ride the WAF wall + per-item logging + don't overwrite a good guide

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,15 +40,17 @@ with no change to the generated guide.
   setting controls the response:
   - `auto` (default) = **adaptive concurrency**: the parallel pool rides the wall
     like a wave — a 429 halves the in-flight workers (collapsing toward one) and
-    slows the shared rate governor, and a clean streak ramps both back up. Every
-    request also carries an adaptive, jittered delay (one worker or several) so
-    the stream looks organic, not metronomic.
+    slows the shared rate governor; if the wall holds it **cools down** to let the
+    server's window reopen (re-queuing the blocked items, not failing them) and
+    **ramps back up** once requests succeed again, repeating as needed. It only
+    gives up (deferring the rest to the next run) after several cooldowns produce
+    no success. Every request also carries an adaptive, jittered delay (one worker
+    or several) so the stream looks organic, not metronomic.
   - a number (e.g. `500`) = download large batches over a single **sequential**
     connection (never rate-limited), parallel below the threshold.
 
-  Either way the pool **aborts early** if the server stays shut (instead of
-  crawling forever), logs blocks/back-offs at WARNING, and **saves details as
-  they arrive** — so an interrupted or aborted run keeps its progress, the rest
+  Either way blocks/back-offs are logged at WARNING and details are **saved as
+  they arrive** — so a deferred or interrupted run keeps its progress, the rest
   is fetched next run, and the process always terminates on its own. Config
   schema → 8.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -53,6 +53,11 @@ with no change to the generated guide.
   schema → 8.
 
 ### Fixed
+- **Never overwrite a good guide with an empty one**: if the guide download
+  returns no programmes at all (e.g. the server rate-limits every block), the
+  run now keeps the existing `xmltv.xml` and exits with an error instead of
+  regenerating an empty guide over it. The next run rebuilds it once the server
+  recovers.
 - **Config backup retention**: timestamped configuration backups
   (`gracenote2epg.xml.backup.*`) were never cleaned up and accumulated
   indefinitely (hundreds of files), many byte-for-byte identical. A new backup

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -75,6 +75,12 @@ with no change to the generated guide.
 - **`--basedir`**: now honoured for the config, cache, log and XMLTV locations.
 
 ### Changed
+- **Download/retention logging**: parallel downloads now trace each item with
+  its id and an `x/y` counter (e.g. `Extended details: SH… (377/1347)`,
+  `Guide block: …`), the per-request adaptive delay names the item it paces, the
+  unified retention summary now includes config backups (`reconf`), and the log
+  rotation period trace reads clearly (`current period, still in progress`
+  instead of `Complete: False`).
 - **Startup logging**: the active config, cache, log and XMLTV paths are now
   shown at startup (log and `--console`).
 - **Internal structure**: `xmltv.py` (947 lines) and `logrotate.py` (657 lines)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,19 +98,20 @@ concurrency reaches sooner; a single sequential connection is never blocked.
 
 - `auto` (default) — **adaptive concurrency**. The pool stays parallel and rides
   the wall like a wave: on a 429 it halves the number of in-flight workers
-  (collapsing toward one) and the rate governor slows down; after a clean streak
-  it ramps both back up. Faster than sequential when the server tolerates short
-  bursts, and it self-tunes. Every request also carries an adaptive, jittered
-  delay (one worker or several), so the stream looks organic rather than
-  metronomic.
+  (collapsing toward one) and the rate governor slows down; if the wall holds it
+  **cools down** to let the server's window reopen (re-queuing the blocked items
+  rather than failing them), and once requests succeed again it **ramps both back
+  up** — repeating as needed. It only **gives up** (deferring the rest to the next
+  run) if several cooldowns in a row produce no success at all. Every request
+  also carries an adaptive, jittered delay (one worker or several), so the stream
+  looks organic rather than metronomic.
 - a positive integer (e.g. `500`) — when at least that many series details are
   pending, download them over a **single sequential connection** (slower but the
   WAF never blocks one connection); below it, parallel as usual.
 
-Either way the pool **aborts early** if the server stays shut (consecutive 429s
-that never recover), and details are **saved as they arrive**, so a partial or
-aborted run keeps its progress, the rest is fetched on the next run, and the
-process always terminates on its own.
+Either way details are **saved as they arrive**, so a partial or deferred run
+keeps its progress, the rest is fetched on the next run, and the process always
+terminates on its own.
 
 ## Image Source
 

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev9"
+__version__ = "2.0.0-dev10"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev10"
+__version__ = "2.0.0-dev11"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/config/retention.py
+++ b/gracenote2epg/config/retention.py
@@ -40,6 +40,17 @@ class RetentionManager:
             settings.get("rexmltv", "7"), "daily"  # XMLTV backups are always daily
         )
 
+        # Config backups (reconf) are a COUNT of distinct versions, not days,
+        # because they are change-triggered rather than periodic. 0 = unlimited.
+        reconf = str(settings.get("reconf", "10")).strip().lower()
+        if reconf in ("unlimited", "0"):
+            config_backup_retention = 0
+        else:
+            try:
+                config_backup_retention = max(0, int(reconf))
+            except ValueError:
+                config_backup_retention = 10
+
         return {
             # Log rotation configuration
             "enabled": rotation_enabled,
@@ -48,10 +59,12 @@ class RetentionManager:
             # Extended retention information
             "log_retention_days": log_retention_days,
             "xmltv_retention_days": xmltv_retention_days,
+            "config_backup_retention": config_backup_retention,  # count, 0=unlimited
             # Original settings for logging
             "logrotate_setting": settings.get("logrotate", "true"),
             "relogs_setting": settings.get("relogs", "30"),
             "rexmltv_setting": settings.get("rexmltv", "7"),
+            "reconf_setting": settings.get("reconf", "10"),
         }
 
     def _parse_retention_to_days(self, retention_value: str, interval: str) -> int:

--- a/gracenote2epg/downloader/guide.py
+++ b/gracenote2epg/downloader/guide.py
@@ -127,24 +127,41 @@ class GuideDownloader(DownloaderStatsMixin):
         if not tasks:
             return
 
+        import threading
+
         existed_map = dict(to_fetch)
-        pool = PacedWorkerPool(execute, workers=workers, session_factory=make_session)
-        # Guide blocks are important: retry failed ones (re-queued at the end).
-        for result in pool.run(tasks, max_attempts=3):
+        total = len(tasks)
+        tally_lock = threading.Lock()
+
+        def on_result(result) -> None:
+            # Runs as each block finalises (save-as-you-go).
             saved = False
             if result.success and result.content:
                 saved = self.cache_manager.validate_and_save_guide_block(
                     result.content, result.task_id
                 )
-            if saved:
-                self.downloaded_count += 1
-            elif existed_map.get(result.task_id):
-                # Refresh failed but the previous version is still on disk.
-                self.cached_count += 1
-            else:
-                self.failed_count += 1
+            with tally_lock:
+                if saved:
+                    self.downloaded_count += 1
+                    note = ""
+                elif existed_map.get(result.task_id):
+                    # Refresh failed but the previous version is still on disk.
+                    self.cached_count += 1
+                    note = " [kept cached]"
+                else:
+                    self.failed_count += 1
+                    note = " [failed]"
+                idx = self.downloaded_count + self.cached_count + self.failed_count
+            logging.debug("  Guide block: %s (%d/%d)%s", result.task_id, idx, total, note)
+
+        pool = PacedWorkerPool(
+            execute, workers=workers, session_factory=make_session, on_result=on_result
+        )
+        # Guide blocks are important: retry failed ones (re-queued at the end).
+        pool.run(tasks, max_attempts=3)
 
         self.http_requests = pool.requests
+        self.rate_limited = pool.rate_limited
         self.rate_limited = pool.rate_limited
 
     def _download_single_block(

--- a/gracenote2epg/downloader/series.py
+++ b/gracenote2epg/downloader/series.py
@@ -119,12 +119,8 @@ class SeriesDownloader(DownloaderStatsMixin):
         total = len(to_download)
         tally_lock = threading.Lock()
 
-        def on_progress(done: int, _total: int):
-            if done == 1 or done % max(1, total // 10) == 0 or done == total:
-                logging.info("  Extended details: %d/%d", done, total)
-
         def on_result(result) -> None:
-            # Runs in worker threads as each download finalises.
+            # Runs in worker threads as each download finalises (save-as-you-go).
             saved = False
             if result.success and result.content:
                 try:
@@ -138,6 +134,17 @@ class SeriesDownloader(DownloaderStatsMixin):
                 else:
                     self.failed_count += 1
                     self.failed_series.append(result.task_id)
+                idx = self.downloaded_count + self.failed_count  # completed so far
+            # Per-item trace (parallel completes out of order) + periodic summary.
+            logging.debug(
+                "  Extended details: %s (%d/%d)%s",
+                result.task_id,
+                idx,
+                total,
+                "" if saved else " [failed]",
+            )
+            if idx == 1 or idx % max(1, total // 10) == 0 or idx == total:
+                logging.info("  Extended details: %d/%d", idx, total)
 
         tasks = [
             DownloadTask(
@@ -153,7 +160,6 @@ class SeriesDownloader(DownloaderStatsMixin):
             execute,
             workers=workers,
             session_factory=make_session,
-            on_progress=on_progress,
             on_result=on_result,
         )
         # Series details are non-critical: one best-effort retry (re-queued at

--- a/gracenote2epg/downloader/worker_pool.py
+++ b/gracenote2epg/downloader/worker_pool.py
@@ -177,7 +177,12 @@ class PacedWorkerPool:
     def _process(self, session, task: DownloadTask) -> DownloadResult:
         """Pace (governed jittered rate), run one request, feed the governor."""
         slept = self._governor.wait()
-        logging.debug("  Adaptive delay: %.2fs (rate %.1f/s)", slept, self._governor.rate)
+        logging.debug(
+            "  Downloading %s (adaptive delay %.2fs, rate %.1f/s)",
+            task.task_id,
+            slept,
+            self._governor.rate,
+        )
         try:
             result = self._execute(session, task)
         except Exception as e:  # never let one task kill a worker

--- a/gracenote2epg/downloader/worker_pool.py
+++ b/gracenote2epg/downloader/worker_pool.py
@@ -16,9 +16,12 @@ signal:
   that collapses toward a single worker on a 429 and ramps back up after a clean
   streak — a "wave" that finds the server's concurrency tolerance.
 
-If the server keeps returning 429, the pool gives up early (accounting the rest
-as failed) so the process always terminates without a manual kill; the leftover
-work is picked up on the next run.
+When the server keeps refusing, the pool **rides the wall** instead of giving up:
+it collapses to a single worker, **cools down** to let the server's window reopen
+(re-queuing the blocked items rather than failing them), and ramps back up once
+requests succeed again — repeating as needed. It only **gives up** (deferring the
+rest to the next run) if several cooldowns in a row produce no success at all, so
+the process always terminates without a manual kill.
 
 The session factory and the per-task execute function are injected, so the pool
 is fully testable without any network.
@@ -51,16 +54,17 @@ class PacedWorkerPool:
         governor: Optional[RateController] = None,
         on_progress: Optional[ProgressFn] = None,
         on_result: Optional[ResultFn] = None,
-        abort_after: int = 40,
         adaptive_concurrency: bool = True,
+        block_threshold: int = 8,
+        max_block_cooldowns: int = 5,
     ):
         self._execute = execute
         self._workers = max(1, workers)
         self._session_factory = session_factory or (lambda: None)
         # Self-regulating rate governor: starts moderate (safe even on a cold run
         # of hundreds of new series), ramps up via AIMD while the server is
-        # happy, backs off on a 429/WAF signal, and jitters each gap so the
-        # stream looks organic.
+        # happy, backs off on a 429/WAF signal, jitters each gap so the stream
+        # looks organic, and pauses (waf_cooldown) when asked to cool down.
         self._governor = governor or RateController(
             initial_rate=5.0,
             max_rate=20.0,
@@ -69,22 +73,26 @@ class PacedWorkerPool:
             success_threshold=10,
             decrease_factor=0.5,
             jitter=0.35,
+            waf_cooldown=30.0,
         )
         # Adaptive concurrency: collapse the in-flight count on 429, ramp back on
         # success. Disabled -> all workers always active (fixed concurrency).
         self._limiter = ConcurrencyLimiter(self._workers) if adaptive_concurrency else None
         self._on_progress = on_progress
         self._on_result = on_result
-        # Stop hitting the server after this many consecutive rate-limited
-        # responses (0 = never abort). A normal "wave" intersperses successes
-        # that reset the counter, so only a persistently shut wall trips it.
-        self._abort_after = abort_after
+        # Wall handling: after this many consecutive 429s, cool down to let the
+        # server recover; give up only after this many cooldowns produce no
+        # success (0 disables both -> never cool down / never give up).
+        self._block_threshold = block_threshold
+        self._max_block_cooldowns = max_block_cooldowns
         self._stats_lock = threading.Lock()
+        self._cooldown_lock = threading.Lock()  # only one worker cools at a time
         self._abort = threading.Event()
         # Aggregate request stats (one entry per attempt), for reporting.
         self.requests = 0
         self.rate_limited = 0
         self._consecutive_rate_limited = 0
+        self._fruitless_cooldowns = 0
 
     @property
     def governor(self) -> RateController:
@@ -101,19 +109,20 @@ class PacedWorkerPool:
     def run(self, tasks: List[DownloadTask], max_attempts: int = 1) -> List[DownloadResult]:
         """Execute *tasks*; returns their final results (order not guaranteed).
 
-        Failed tasks (including rate-limited ones) are re-queued at the **end**
-        and retried up to ``max_attempts`` total. If the server keeps
-        rate-limiting, the pool aborts early (see module docstring) rather than
-        looping.
+        Genuine errors are re-queued at the end and retried up to ``max_attempts``
+        total. Rate-limited (429) results are re-queued **without** consuming that
+        budget — the pool rides the wall (see module docstring) and only gives up
+        after repeated fruitless cooldowns.
         """
         if not tasks:
             return []
         self.requests = 0
         self.rate_limited = 0
         self._consecutive_rate_limited = 0
+        self._fruitless_cooldowns = 0
         self._abort.clear()
 
-        # Queue carries (task, attempt_number).
+        # Queue carries (task, error_attempt_number).
         work: "queue.Queue" = queue.Queue()
         for task in tasks:
             work.put((task, 1))
@@ -134,7 +143,7 @@ class PacedWorkerPool:
         """One worker: own a persistent session, drain the queue (with requeue)."""
         session = self._session_factory()
         try:
-            # Terminate on finalised count, not queue-empty, because failures get
+            # Terminate on finalised count, not queue-empty, because items get
             # re-queued (a worker could otherwise exit while a requeue is pending).
             while not sink.complete:
                 try:
@@ -142,12 +151,18 @@ class PacedWorkerPool:
                 except queue.Empty:
                     continue
                 if self._abort.is_set():
-                    # Don't touch the server any more; account the item as failed
-                    # so the pool finishes promptly instead of crawling.
-                    sink.add(DownloadResult(task.task_id, success=False, error="aborted"))
+                    # Gave up on the wall; account remaining items as failed so
+                    # the pool finishes promptly (the next run picks them up).
+                    sink.add(DownloadResult(task.task_id, success=False, error="deferred"))
                     continue
                 result = self._process_gated(session, task)
-                if not result.success and attempt < max_attempts and not self._abort.is_set():
+                if result.success:
+                    sink.add(result)
+                elif result.rate_limited and not self._abort.is_set():
+                    # Ride the wall: retry later without spending the error budget.
+                    logging.debug("Requeue %s (rate-limited, riding the wall)", task.task_id)
+                    work.put((task, attempt))
+                elif not result.success and attempt < max_attempts and not self._abort.is_set():
                     logging.debug("Requeue %s (attempt %d/%d)", task.task_id, attempt, max_attempts)
                     work.put((task, attempt + 1))
                 else:
@@ -192,32 +207,63 @@ class PacedWorkerPool:
             self._governor.on_rate_limited()
         elif result.success:
             self._governor.on_success()
-        self._record(result)
+        self._note(result)
         return result
 
-    def _record(self, result: DownloadResult) -> None:
-        """Update stats and trip the early-abort once the wall stays shut."""
+    def _note(self, result: DownloadResult) -> None:
+        """Update stats; cool down on a sustained wall, recover on success."""
         with self._stats_lock:
             self.requests += 1
             if result.rate_limited:
                 self.rate_limited += 1
                 self._consecutive_rate_limited += 1
             elif result.success:
+                # Recovered: forget the streak and the cooldown budget.
                 self._consecutive_rate_limited = 0
+                self._fruitless_cooldowns = 0
             consecutive = self._consecutive_rate_limited
-        if result.rate_limited:
+
+        if not result.rate_limited:
+            return
+
+        logging.warning(
+            "Rate-limited/blocked (HTTP %s) on %s", result.http_code or "?", result.task_id
+        )
+        if self._block_threshold and consecutive >= self._block_threshold:
+            self._cool_down()
+
+    def _cool_down(self) -> None:
+        """Collapsed-and-still-blocked: pause to let the server's window reopen.
+
+        Only one worker cools down at a time. After ``max_block_cooldowns``
+        cooldowns without any intervening success, give up (defer the rest to the
+        next run) so the run always terminates.
+        """
+        if not self._cooldown_lock.acquire(blocking=False):
+            return  # another worker is already cooling down
+        try:
+            with self._stats_lock:
+                self._consecutive_rate_limited = 0
+                self._fruitless_cooldowns += 1
+                cooldowns = self._fruitless_cooldowns
+            if self._max_block_cooldowns and cooldowns > self._max_block_cooldowns:
+                if not self._abort.is_set():
+                    self._abort.set()
+                    logging.warning(
+                        "Still rate-limited after %d cooldowns; deferring the rest to the next "
+                        "run (it will resume once the server's window reopens).",
+                        cooldowns - 1,
+                    )
+                return
             logging.warning(
-                "Rate-limited/blocked (HTTP %s) on %s",
-                result.http_code or "?",
-                result.task_id,
+                "Rate-limit wall hit; collapsing to a single worker and cooling down "
+                "(%d/%d) to let the server recover.",
+                cooldowns,
+                self._max_block_cooldowns,
             )
-        if self._abort_after and consecutive >= self._abort_after and not self._abort.is_set():
-            self._abort.set()
-            logging.warning(
-                "Server rate-limited %d requests in a row (HTTP 429); stopping the parallel "
-                "batch early. The remaining items will be downloaded on the next run.",
-                consecutive,
-            )
+            self._governor.on_waf_block()  # backs off + sleeps the cooldown
+        finally:
+            self._cooldown_lock.release()
 
 
 class _ResultSink:

--- a/gracenote2epg/logrotate/handler.py
+++ b/gracenote2epg/logrotate/handler.py
@@ -167,13 +167,15 @@ class CopyTruncateTimedRotatingFileHandler(logging.handlers.BaseRotatingHandler)
                                 "last_line": line_num,
                             }
 
+                            span = period_start.strftime("%Y-%m-%d")
+                            if period_end != period_start:
+                                span += " to " + period_end.strftime("%Y-%m-%d")
                             logging.debug(
-                                "Found %s %s (%s to %s) - Complete: %s",
+                                "Found %s log period %s (%s) - %s",
                                 self.period_name,
                                 period_suffix,
-                                period_start.strftime("%Y-%m-%d"),
-                                period_end.strftime("%Y-%m-%d"),
-                                is_complete,
+                                span,
+                                "complete" if is_complete else "current period, still in progress",
                             )
 
                         # Add line to this period

--- a/gracenote2epg/main.py
+++ b/gracenote2epg/main.py
@@ -139,6 +139,11 @@ def setup_logging(logging_config: dict, log_file: Path, retention_config: dict):
             log_retention,
         )
         logging.debug("  XMLTV backups: %d days retention", xmltv_retention)
+        config_backups = retention_config.get("config_backup_retention", 10)
+        logging.debug(
+            "  Config backups: %s",
+            "unlimited" if config_backups == 0 else "%d kept" % config_backups,
+        )
         logging.debug(
             "  Current log size: %d bytes, backup files: %d",
             rotation_status.get("current_log_size", 0),

--- a/gracenote2epg/main.py
+++ b/gracenote2epg/main.py
@@ -371,8 +371,28 @@ def main():
             xmltv_generator = XmltvGenerator(
                 cache_manager, image_base_url=config_manager.get_image_source()
             )
+            schedule = data_parser.get_schedule()
+
+            # Safety: if the guide produced no programmes at all (e.g. the server
+            # rate-limited every block), do NOT overwrite a previously good
+            # xmltv.xml with an empty guide. Leave it untouched and fail — the
+            # next run (after the WAF window resets) will rebuild it.
+            episode_count = sum(
+                1
+                for station_data in schedule.values()
+                for key in station_data
+                if not key.startswith("ch")
+            )
+            if episode_count == 0:
+                logging.error(
+                    "No guide data available (guide download failed or returned nothing); "
+                    "keeping the existing xmltv.xml rather than overwriting it with an empty "
+                    "guide. Will retry on the next run."
+                )
+                return 1
+
             xmltv_success = xmltv_generator.generate_xmltv(
-                schedule=data_parser.get_schedule(), config=config, xmltv_file=xmltv_file
+                schedule=schedule, config=config, xmltv_file=xmltv_file
             )
 
             if not xmltv_success:

--- a/tests/test_worker_pool.py
+++ b/tests/test_worker_pool.py
@@ -169,41 +169,72 @@ class RetryTests(unittest.TestCase):
         self.assertEqual(pool.requests, 4)  # one attempt each
 
     def test_stats_count_requests_and_rate_limited(self):
+        # A permanently shut wall: rides it, cools down, then gives up.
         def execute(session, task):
             return DownloadResult(task.task_id, success=False, rate_limited=True)
 
-        pool = PacedWorkerPool(execute, workers=2, governor=instant_governor())
-        pool.run(tasks(4), max_attempts=1)
-        self.assertEqual(pool.requests, 4)
-        self.assertEqual(pool.rate_limited, 4)
+        pool = PacedWorkerPool(
+            execute,
+            workers=2,
+            governor=instant_governor(),
+            block_threshold=2,
+            max_block_cooldowns=1,
+        )
+        results = pool.run(tasks(4), max_attempts=1)
+        self.assertEqual(len(results), 4)
+        self.assertTrue(pool.aborted)
+        self.assertEqual(pool.rate_limited, pool.requests)  # every request was a 429
+        self.assertGreater(pool.requests, 0)
 
 
-class EarlyAbortTests(unittest.TestCase):
-    def test_pool_aborts_and_terminates_when_server_always_429s(self):
+class WallHandlingTests(unittest.TestCase):
+    def test_gives_up_after_fruitless_cooldowns_and_terminates(self):
         # A server stuck behind its WAF wall: every request is rate-limited.
         def execute(session, task):
             return DownloadResult(task.task_id, success=False, rate_limited=True)
 
-        pool = PacedWorkerPool(execute, workers=4, governor=instant_governor(), abort_after=10)
+        pool = PacedWorkerPool(
+            execute,
+            workers=4,
+            governor=instant_governor(),
+            block_threshold=4,
+            max_block_cooldowns=3,
+        )
         results = pool.run(tasks(500), max_attempts=2)
 
-        # It must STOP on its own (no endless crawl / requeue loop)...
+        # It must STOP on its own (cooldowns that never recover -> give up)...
         self.assertTrue(pool.aborted)
         # ...account every task exactly once so run() returns...
         self.assertEqual(len(results), 500)
         self.assertEqual({r.task_id for r in results}, {str(i) for i in range(500)})
         self.assertTrue(all(not r.success for r in results))
-        # ...and it must have stopped EARLY rather than hammering all 500x2.
+        # ...and it must have stopped EARLY rather than hammering all 500.
         self.assertLess(pool.requests, 500)
 
-    def test_no_abort_when_disabled(self):
-        def execute(session, task):
-            return DownloadResult(task.task_id, success=False, rate_limited=True)
+    def test_rides_the_wall_then_recovers_without_giving_up(self):
+        # First 20 requests are blocked, then the server recovers.
+        state = {"n": 0}
+        lock = threading.Lock()
 
-        pool = PacedWorkerPool(execute, workers=2, governor=instant_governor(), abort_after=0)
-        results = pool.run(tasks(20), max_attempts=1)
-        self.assertFalse(pool.aborted)
-        self.assertEqual(len(results), 20)  # still terminates (bounded by max_attempts)
+        def execute(session, task):
+            with lock:
+                state["n"] += 1
+                limited = state["n"] <= 20
+            return DownloadResult(task.task_id, success=not limited, rate_limited=limited)
+
+        pool = PacedWorkerPool(
+            execute,
+            workers=4,
+            governor=instant_governor(),
+            block_threshold=4,
+            max_block_cooldowns=10,
+        )
+        results = pool.run(tasks(60), max_attempts=1)
+
+        self.assertFalse(pool.aborted)  # recovered instead of giving up
+        self.assertEqual(len(results), 60)
+        # The blocked items were re-queued (not failed) and succeeded on retry.
+        self.assertTrue(all(r.success for r in results))
 
 
 class AdaptiveConcurrencyTests(unittest.TestCase):
@@ -220,11 +251,11 @@ class AdaptiveConcurrencyTests(unittest.TestCase):
             limits.append(pool.concurrency_limit)
             return DownloadResult(task.task_id, success=not limited, rate_limited=limited)
 
-        # abort disabled so the early-stop doesn't pre-empt the wave.
-        pool = PacedWorkerPool(execute, workers=8, governor=instant_governor(), abort_after=0)
+        pool = PacedWorkerPool(execute, workers=8, governor=instant_governor())
         results = pool.run(tasks(120), max_attempts=1)
 
         self.assertEqual(len(results), 120)  # all accounted, no deadlock
+        self.assertFalse(pool.aborted)  # rode it out, recovered
         self.assertLess(min(limits), 8)  # the in-flight ceiling collapsed
         self.assertEqual(min(limits), 1)  # all the way down to a single worker
 
@@ -239,11 +270,14 @@ class AdaptiveConcurrencyTests(unittest.TestCase):
             execute,
             workers=4,
             governor=instant_governor(),
-            abort_after=0,
             adaptive_concurrency=False,
+            block_threshold=4,
+            max_block_cooldowns=2,
         )
-        pool.run(tasks(20), max_attempts=1)
+        results = pool.run(tasks(20), max_attempts=1)
         self.assertTrue(all(limit == 4 for limit in seen))  # never collapses
+        self.assertTrue(pool.aborted)  # still terminates (gives up on the wall)
+        self.assertEqual(len(results), 20)
 
 
 class OnResultTests(unittest.TestCase):


### PR DESCRIPTION
Everything found while testing the merged adaptive-concurrency run (#19) on a cold cache, in one PR.

## 1. Ride the WAF wall instead of giving up (the main change)

Exactly the behaviour you described: **hit a wall → collapse to one worker → keep auto-scaling/cooling until it recovers → re-deploy the workers → repeat as needed**, only giving up if it truly never recovers.

On your cold-cache run, `dlthreshold=auto` got **424 of ~1900** series then **aborted**, dropping ~1490 as "failed" (582 requests, only 46 rate-limited — the rest never tried). Your **sequential** run recovered through ~4 walls because it slowed enough for the server's window to reopen. Now `auto` does the same:

- **429 results are re-queued without consuming the error-retry budget** — the pool keeps the work instead of failing it.
- On a sustained wall it **collapses to a single worker and cools down** (`governor.on_waf_block()` pauses ~30s to let the window reopen), then **ramps back up** once requests succeed again — repeating as needed.
- It **gives up only** after several cooldowns in a row with *no* success (truly dead server) → defers the rest to the next run. So it **always terminates** on its own, no manual kill.

Replaces `abort_after` with `block_threshold` / `max_block_cooldowns`; genuine (non-429) errors still use `max_attempts`.

## 2. Never overwrite a good guide with an empty one (safety)

If the guide download yields **zero** programmes (server 429s every block), the run now keeps the existing `xmltv.xml` and exits 1 instead of regenerating an empty 167-byte guide over it. The next run rebuilds it.

## 3. Logging / visibility

- Parallel downloads trace each item with its id and an `x/y` counter (`Extended details: SH… (377/1347)`, `Guide block: …`); the per-request adaptive-delay line names the item; **save-as-you-go** now also covers guide blocks.
- Unified retention summary includes config backups (`Config backups: 10 kept`).
- Log-rotation period trace reads clearly (`current period, still in progress`).

## Tests (121, green)

`WallHandlingTests` (give-up-and-terminate; ride-then-recover), `AdaptiveConcurrencyTests` (collapse→recover), plus the existing pacing/concurrency/config suites. `black` + `flake8` clean. Version → **dev11**.

Meanwhile `dlthreshold=500` stays the proven one-shot sequential path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
