### PR TITLE
downloader: escalating per-request delay (replaces the fixed cooldown from #21)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ gracenote2epg.egg-info
 
 # Local test baseline (user-provided NAS data, not for VCS)
 tests/baseline/
+
+# Local debug logs (never commit)
+debug/

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,12 +40,13 @@ with no change to the generated guide.
   setting controls the response:
   - `auto` (default) = **adaptive concurrency**: the parallel pool rides the wall
     like a wave — a 429 halves the in-flight workers (collapsing toward one) and
-    slows the shared rate governor; if the wall holds it **cools down** to let the
-    server's window reopen (re-queuing the blocked items, not failing them) and
-    **ramps back up** once requests succeed again, repeating as needed. It only
-    gives up (deferring the rest to the next run) after several cooldowns produce
-    no success. Every request also carries an adaptive, jittered delay (one worker
-    or several) so the stream looks organic, not metronomic.
+    **escalates the per-request delay** (up to ~15s, like a backing-off client) so
+    requests space out until one lands in a reopened window (re-queuing the
+    blocked items, not failing them); a success resets the delay and the workers
+    ramp back up. It only gives up (deferring the rest to the next run) after a
+    long run of consecutive 429s with no recovery. Every request also carries an
+    adaptive, jittered delay (one worker or several) so the stream looks organic,
+    not metronomic.
   - a number (e.g. `500`) = download large batches over a single **sequential**
     connection (never rate-limited), parallel below the threshold.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,13 +98,13 @@ concurrency reaches sooner; a single sequential connection is never blocked.
 
 - `auto` (default) — **adaptive concurrency**. The pool stays parallel and rides
   the wall like a wave: on a 429 it halves the number of in-flight workers
-  (collapsing toward one) and the rate governor slows down; if the wall holds it
-  **cools down** to let the server's window reopen (re-queuing the blocked items
-  rather than failing them), and once requests succeed again it **ramps both back
-  up** — repeating as needed. It only **gives up** (deferring the rest to the next
-  run) if several cooldowns in a row produce no success at all. Every request
-  also carries an adaptive, jittered delay (one worker or several), so the stream
-  looks organic rather than metronomic.
+  (collapsing toward one) and **escalates the per-request delay** (growing up to
+  ~15s, like a backing-off client) so requests space out until one lands in a
+  reopened window — re-queuing the blocked items rather than failing them. A
+  success resets the delay and the workers **ramp back up**. It only **gives up**
+  (deferring the rest to the next run) after a long run of consecutive 429s with
+  no recovery. Every request also carries an adaptive, jittered delay (one worker
+  or several), so the stream looks organic rather than metronomic.
 - a positive integer (e.g. `500`) — when at least that many series details are
   pending, download them over a **single sequential connection** (slower but the
   WAF never blocks one connection); below it, parallel as usual.

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev11"
+__version__ = "2.0.0-dev12"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/downloader/pacing.py
+++ b/gracenote2epg/downloader/pacing.py
@@ -38,6 +38,8 @@ class RateController:
         success_threshold: int = 10,
         waf_cooldown: float = 20.0,
         jitter: float = 0.0,
+        failure_base: float = 0.0,
+        max_delay: float = 15.0,
         clock: Callable[[], float] = time.monotonic,
         sleep: Callable[[float], None] = time.sleep,
         rng: Callable[[], float] = random.random,
@@ -52,6 +54,12 @@ class RateController:
         self._waf_cooldown = waf_cooldown
         # Fraction (0..1) by which each gap is randomly stretched/shrunk.
         self._jitter = max(0.0, min(1.0, jitter))
+        # Escalating per-request delay on a sustained wall: once past a couple of
+        # consecutive 429s the gap grows ~failure_base*1.5^failures (capped at
+        # max_delay), so each request is spaced increasingly far apart until one
+        # lands in a reopened window — then a success resets it. 0 disables it.
+        self._failure_base = max(0.0, failure_base)
+        self._max_delay = max_delay
         self._clock = clock
         self._sleep = sleep
         self._rng = rng
@@ -59,6 +67,7 @@ class RateController:
         self._lock = threading.Lock()
         self.rate = self._clamp(initial_rate)
         self._successes = 0
+        self._consecutive_failures = 0
         self._next_allowed: Optional[float] = None
 
     def _clamp(self, rate: float) -> float:
@@ -79,6 +88,14 @@ class RateController:
         with self._lock:
             now = self._clock()
             gap = 1.0 / self.rate
+            # On a sustained wall, escalate the per-request spacing (like a
+            # backing-off client) so requests don't keep hammering the closed
+            # window at the rate floor.
+            if self._failure_base and self._consecutive_failures > 2:
+                escalated = min(
+                    self._failure_base * (1.5**self._consecutive_failures), self._max_delay
+                )
+                gap = max(gap, escalated)
             if self._jitter:
                 gap *= 1.0 + (self._rng() * 2.0 - 1.0) * self._jitter
             start = now if self._next_allowed is None else max(now, self._next_allowed)
@@ -91,6 +108,12 @@ class RateController:
     def on_success(self) -> None:
         """Additive increase: speed up after a streak of clean requests."""
         with self._lock:
+            if self._consecutive_failures > 0:
+                # Recovering from a wall: drop the long reserved gap so the next
+                # request exploits the reopened window immediately instead of
+                # waiting out the last escalated delay.
+                self._consecutive_failures = 0
+                self._next_allowed = None
             self._successes += 1
             if self._successes >= self._success_threshold:
                 self._successes = 0
@@ -100,6 +123,7 @@ class RateController:
         """Multiplicative decrease: back off on a 429 / Too Many Requests."""
         with self._lock:
             self._successes = 0
+            self._consecutive_failures += 1  # grows the escalating per-request delay
             self.rate = self._clamp(self.rate * self._decrease_factor)
 
     def on_waf_block(self) -> None:

--- a/gracenote2epg/downloader/worker_pool.py
+++ b/gracenote2epg/downloader/worker_pool.py
@@ -17,11 +17,12 @@ signal:
   streak — a "wave" that finds the server's concurrency tolerance.
 
 When the server keeps refusing, the pool **rides the wall** instead of giving up:
-it collapses to a single worker, **cools down** to let the server's window reopen
-(re-queuing the blocked items rather than failing them), and ramps back up once
-requests succeed again — repeating as needed. It only **gives up** (deferring the
-rest to the next run) if several cooldowns in a row produce no success at all, so
-the process always terminates without a manual kill.
+concurrency collapses toward a single worker and the governor **escalates the
+per-request delay** (up to ~15s, like a backing-off client) so requests space out
+until one lands in a reopened window — re-queuing the blocked items rather than
+failing them — then ramps back up once requests succeed again. It only **gives
+up** (deferring the rest to the next run) after a long run of consecutive 429s
+with no recovery, so the process always terminates without a manual kill.
 
 The session factory and the per-task execute function are injected, so the pool
 is fully testable without any network.
@@ -55,44 +56,41 @@ class PacedWorkerPool:
         on_progress: Optional[ProgressFn] = None,
         on_result: Optional[ResultFn] = None,
         adaptive_concurrency: bool = True,
-        block_threshold: int = 8,
-        max_block_cooldowns: int = 5,
+        give_up_after: int = 25,
     ):
         self._execute = execute
         self._workers = max(1, workers)
         self._session_factory = session_factory or (lambda: None)
-        # Self-regulating rate governor: starts moderate (safe even on a cold run
-        # of hundreds of new series), ramps up via AIMD while the server is
-        # happy, backs off on a 429/WAF signal, jitters each gap so the stream
-        # looks organic, and pauses (waf_cooldown) when asked to cool down.
+        # Self-regulating rate governor: ramps up via AIMD while the server is
+        # happy, jitters each gap so the stream looks organic, and on a sustained
+        # wall escalates the per-request delay (up to ~15s) so requests space out
+        # like a backing-off client until one lands in a reopened window.
         self._governor = governor or RateController(
             initial_rate=5.0,
             max_rate=20.0,
             min_rate=0.5,
             increase_step=0.5,
-            success_threshold=10,
+            success_threshold=5,
             decrease_factor=0.5,
             jitter=0.35,
-            waf_cooldown=30.0,
+            failure_base=0.8,
+            max_delay=15.0,
         )
         # Adaptive concurrency: collapse the in-flight count on 429, ramp back on
         # success. Disabled -> all workers always active (fixed concurrency).
         self._limiter = ConcurrencyLimiter(self._workers) if adaptive_concurrency else None
         self._on_progress = on_progress
         self._on_result = on_result
-        # Wall handling: after this many consecutive 429s, cool down to let the
-        # server recover; give up only after this many cooldowns produce no
-        # success (0 disables both -> never cool down / never give up).
-        self._block_threshold = block_threshold
-        self._max_block_cooldowns = max_block_cooldowns
+        # Give up (defer the rest to the next run) after this many consecutive
+        # 429s with no intervening success — i.e. the escalating delay reached its
+        # ceiling and the wall still won't reopen. 0 = never give up.
+        self._give_up_after = give_up_after
         self._stats_lock = threading.Lock()
-        self._cooldown_lock = threading.Lock()  # only one worker cools at a time
         self._abort = threading.Event()
         # Aggregate request stats (one entry per attempt), for reporting.
         self.requests = 0
         self.rate_limited = 0
         self._consecutive_rate_limited = 0
-        self._fruitless_cooldowns = 0
 
     @property
     def governor(self) -> RateController:
@@ -112,14 +110,13 @@ class PacedWorkerPool:
         Genuine errors are re-queued at the end and retried up to ``max_attempts``
         total. Rate-limited (429) results are re-queued **without** consuming that
         budget — the pool rides the wall (see module docstring) and only gives up
-        after repeated fruitless cooldowns.
+        after a long run of consecutive 429s with no recovery.
         """
         if not tasks:
             return []
         self.requests = 0
         self.rate_limited = 0
         self._consecutive_rate_limited = 0
-        self._fruitless_cooldowns = 0
         self._abort.clear()
 
         # Queue carries (task, error_attempt_number).
@@ -211,59 +208,34 @@ class PacedWorkerPool:
         return result
 
     def _note(self, result: DownloadResult) -> None:
-        """Update stats; cool down on a sustained wall, recover on success."""
+        """Update stats; track the 429 streak and give up if it never recovers."""
         with self._stats_lock:
             self.requests += 1
             if result.rate_limited:
                 self.rate_limited += 1
                 self._consecutive_rate_limited += 1
             elif result.success:
-                # Recovered: forget the streak and the cooldown budget.
-                self._consecutive_rate_limited = 0
-                self._fruitless_cooldowns = 0
+                self._consecutive_rate_limited = 0  # recovered
             consecutive = self._consecutive_rate_limited
 
         if not result.rate_limited:
             return
 
         logging.warning(
-            "Rate-limited/blocked (HTTP %s) on %s", result.http_code or "?", result.task_id
+            "HTTP %s (rate-limited) on %s - %d consecutive 429 error(s), backing off "
+            "with an escalating delay",
+            result.http_code or "429",
+            result.task_id,
+            consecutive,
         )
-        if self._block_threshold and consecutive >= self._block_threshold:
-            self._cool_down()
-
-    def _cool_down(self) -> None:
-        """Collapsed-and-still-blocked: pause to let the server's window reopen.
-
-        Only one worker cools down at a time. After ``max_block_cooldowns``
-        cooldowns without any intervening success, give up (defer the rest to the
-        next run) so the run always terminates.
-        """
-        if not self._cooldown_lock.acquire(blocking=False):
-            return  # another worker is already cooling down
-        try:
-            with self._stats_lock:
-                self._consecutive_rate_limited = 0
-                self._fruitless_cooldowns += 1
-                cooldowns = self._fruitless_cooldowns
-            if self._max_block_cooldowns and cooldowns > self._max_block_cooldowns:
-                if not self._abort.is_set():
-                    self._abort.set()
-                    logging.warning(
-                        "Still rate-limited after %d cooldowns; deferring the rest to the next "
-                        "run (it will resume once the server's window reopens).",
-                        cooldowns - 1,
-                    )
-                return
+        if self._give_up_after and consecutive >= self._give_up_after and not self._abort.is_set():
+            self._abort.set()
             logging.warning(
-                "Rate-limit wall hit; collapsing to a single worker and cooling down "
-                "(%d/%d) to let the server recover.",
-                cooldowns,
-                self._max_block_cooldowns,
+                "Still getting HTTP 429 after %d consecutive rate-limited errors at the maximum "
+                "back-off; deferring the remaining downloads to the next run (they resume once "
+                "the server's window reopens).",
+                consecutive,
             )
-            self._governor.on_waf_block()  # backs off + sleeps the cooldown
-        finally:
-            self._cooldown_lock.release()
 
 
 class _ResultSink:

--- a/tests/test_pacing.py
+++ b/tests/test_pacing.py
@@ -92,6 +92,36 @@ class RateControllerPacingTests(unittest.TestCase):
         rc.wait()
         self.assertAlmostEqual(t.slept[-1], 0.3, places=6)  # only the remainder
 
+    def test_delay_escalates_on_sustained_429s_then_resets_on_success(self):
+        t = FakeTime()
+        rc = RateController(
+            initial_rate=5.0,  # base interval 0.2s when healthy
+            min_rate=0.5,
+            failure_base=0.8,
+            max_delay=15.0,
+            clock=t.clock,
+            sleep=t.sleep,
+        )
+        rc.wait()  # prime _next_allowed (no sleep yet)
+
+        # Sustained 429s -> the per-request gap grows well past the rate floor.
+        gaps = []
+        for _ in range(8):
+            rc.on_rate_limited()
+            rc.wait()
+            gaps.append(t.slept[-1])
+        # Climbs and approaches the 15s cap (0.8 * 1.5^8 = 20 -> capped at 15).
+        self.assertGreater(gaps[-1], gaps[0])
+        self.assertGreater(gaps[-1], 10.0)
+        self.assertLessEqual(gaps[-1], 15.0)
+
+        # A success clears the streak and the long reserved gap: the next request
+        # fires immediately (sleeps 0, so nothing is recorded).
+        rc.on_success()
+        before = len(t.slept)
+        rc.wait()
+        self.assertEqual(len(t.slept), before)
+
     def test_waf_block_backs_off_and_cools_down(self):
         t = FakeTime()
         rc = RateController(

--- a/tests/test_worker_pool.py
+++ b/tests/test_worker_pool.py
@@ -169,7 +169,7 @@ class RetryTests(unittest.TestCase):
         self.assertEqual(pool.requests, 4)  # one attempt each
 
     def test_stats_count_requests_and_rate_limited(self):
-        # A permanently shut wall: rides it, cools down, then gives up.
+        # A permanently shut wall: rides it (escalating delay), then gives up.
         def execute(session, task):
             return DownloadResult(task.task_id, success=False, rate_limited=True)
 
@@ -177,8 +177,7 @@ class RetryTests(unittest.TestCase):
             execute,
             workers=2,
             governor=instant_governor(),
-            block_threshold=2,
-            max_block_cooldowns=1,
+            give_up_after=4,
         )
         results = pool.run(tasks(4), max_attempts=1)
         self.assertEqual(len(results), 4)
@@ -188,7 +187,7 @@ class RetryTests(unittest.TestCase):
 
 
 class WallHandlingTests(unittest.TestCase):
-    def test_gives_up_after_fruitless_cooldowns_and_terminates(self):
+    def test_gives_up_after_persistent_429s_and_terminates(self):
         # A server stuck behind its WAF wall: every request is rate-limited.
         def execute(session, task):
             return DownloadResult(task.task_id, success=False, rate_limited=True)
@@ -197,8 +196,7 @@ class WallHandlingTests(unittest.TestCase):
             execute,
             workers=4,
             governor=instant_governor(),
-            block_threshold=4,
-            max_block_cooldowns=3,
+            give_up_after=8,
         )
         results = pool.run(tasks(500), max_attempts=2)
 
@@ -226,8 +224,7 @@ class WallHandlingTests(unittest.TestCase):
             execute,
             workers=4,
             governor=instant_governor(),
-            block_threshold=4,
-            max_block_cooldowns=10,
+            give_up_after=30,
         )
         results = pool.run(tasks(60), max_attempts=1)
 
@@ -251,7 +248,7 @@ class AdaptiveConcurrencyTests(unittest.TestCase):
             limits.append(pool.concurrency_limit)
             return DownloadResult(task.task_id, success=not limited, rate_limited=limited)
 
-        pool = PacedWorkerPool(execute, workers=8, governor=instant_governor())
+        pool = PacedWorkerPool(execute, workers=8, governor=instant_governor(), give_up_after=50)
         results = pool.run(tasks(120), max_attempts=1)
 
         self.assertEqual(len(results), 120)  # all accounted, no deadlock
@@ -271,8 +268,7 @@ class AdaptiveConcurrencyTests(unittest.TestCase):
             workers=4,
             governor=instant_governor(),
             adaptive_concurrency=False,
-            block_threshold=4,
-            max_block_cooldowns=2,
+            give_up_after=8,
         )
         results = pool.run(tasks(20), max_attempts=1)
         self.assertTrue(all(limit == 4 for limit in seen))  # never collapses


### PR DESCRIPTION
**Follow-up to #21.** #21 merged at the *cooldown* version (dev11); this brings the fix you validated against your NAS logs (dev12). `main` currently has the broken behaviour.

## The problem (from your logs)

The 30s one-shot cooldown then fired a **burst of requests at the 0.5/s floor** (≈2s apart) → every post-cooldown request 429'd again → another 30s pause. It never let the server's window reopen.

Your **sequential** engine recovered because it grew its **per-request delay up to ~15s** until a request landed in a reopened window.

## The fix

Port that proven model into the parallel governor:

- On a sustained 429 the governor **escalates the per-request delay** (`~failure_base*1.5^consecutive`, capped ~15s) — each request spaces out further, like a backing-off client, instead of bursting.
- A **success resets** the delay **and the reserved gap**, so recovery is immediate (exploits the reopened window) and the workers ramp back up.
- Gives up only after `give_up_after` consecutive 429s with no recovery (default 25) → defers the rest to the next run. Still always terminates.
- Clearer WARNING wording: `N consecutive 429 error(s)` so the count isn't mistaken for the server's ~500 budget.

## Tests (122, green)

`test_pacing` gains an escalate-then-reset test; `WallHandlingTests` covers give-up-and-terminate and ride-then-recover. `black` + `flake8` clean. Version → **dev12**.

> Re-created cleanly from `main` (the original dev12 commits on `dl-ride-the-wall` had accidentally swept in 79 MB of local debug logs — excluded here, and `debug/` is now gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
