### PR TITLE
downloader: widen the give-up margin (give_up_after 25 → 40)

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,8 @@
+./tv_imagecache_audit.py
+ --->> indiquer si la cache est active ou pas
+ --->> rendre l'installation optionnelle
+
+download throttling:
+ --->> état où si cache désactivée (et même nettoyée!) on reste en mode http: 192.168.80.89: HTTP/1.1 HEAD (2) /imagecache/1054 -- 404
+
+TVH: corriger le problème avec le rating XMLTV

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev12"
+__version__ = "2.0.0-dev13"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/downloader/worker_pool.py
+++ b/gracenote2epg/downloader/worker_pool.py
@@ -56,7 +56,7 @@ class PacedWorkerPool:
         on_progress: Optional[ProgressFn] = None,
         on_result: Optional[ResultFn] = None,
         adaptive_concurrency: bool = True,
-        give_up_after: int = 25,
+        give_up_after: int = 40,
     ):
         self._execute = execute
         self._workers = max(1, workers)
@@ -83,7 +83,8 @@ class PacedWorkerPool:
         self._on_result = on_result
         # Give up (defer the rest to the next run) after this many consecutive
         # 429s with no intervening success — i.e. the escalating delay reached its
-        # ceiling and the wall still won't reopen. 0 = never give up.
+        # ceiling and the wall still won't reopen. Observed real recoveries take
+        # up to ~15 in a row, so the default keeps a wide margin. 0 = never give up.
         self._give_up_after = give_up_after
         self._stats_lock = threading.Lock()
         self._abort = threading.Event()


### PR DESCRIPTION
Tuning follow-up to #22, from a real NAS test.

On a cold-cache run the wall recovered after **15 consecutive 429s** (the escalating delay climbed to ~15s, then a success). `give_up_after=25` only left 10 of margin, so raise the default to **40** — a more heavily-primed server gets plenty of room to reopen before the pool defers the rest to the next run. The worst-case dead-server crawl stays bounded (the per-request delay caps at ~15s, so 40 ≈ a few minutes, then it defers and save-as-you-go keeps the progress).

No behaviour change otherwise; 122 tests green, `black`/`flake8` clean. Version → **dev13**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
