### PR TITLE
docs: unit-testing guide (unittesting.md) + make tests/test-one/golden-update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for gracenote2epg development
 # Provides convenient shortcuts for common development tasks
 
-.PHONY: help clean autofix format lint test-unit test test-basic test-full geodata build install-dev check-deps show-dist all
+.PHONY: help clean autofix format lint test-unit tests test-one golden-update test test-basic test-full geodata build install-dev check-deps show-dist all
 
 # Default target
 help:
@@ -14,6 +14,9 @@ help:
 	@echo "  format       Format code with black"
 	@echo "  lint         Run linting with flake8"
 	@echo "  test-unit    Run unit tests (stdlib unittest, no extra deps)"
+	@echo "  tests        Alias for test-unit"
+	@echo "  test-one     Run one test module: make test-one T=test_worker_pool"
+	@echo "  golden-update Regenerate the XMLTV golden file (after an intended format change)"
 	@echo "  test-basic   Basic functionality test"
 	@echo "  test-full    Full distribution test"
 	@echo "  test         Alias for test-full"
@@ -49,6 +52,20 @@ lint:
 
 test-unit:
 	@python3 -m unittest discover -s tests -p "test_*.py" -v
+
+# Alias — `make tests` runs the full stdlib unittest suite.
+tests: test-unit
+
+# Run a single test module, e.g. `make test-one T=test_worker_pool`
+# (T may also be a class or method path, e.g. test_worker_pool.WallHandlingTests).
+test-one:
+	@python3 -m unittest -v tests.$(T)
+
+# Regenerate the XMLTV golden file after an INTENTIONAL change to the generator's
+# output format; review the diff before committing.
+golden-update:
+	@python3 -m tests.test_xmltv_golden --update-golden
+	@echo "Golden regenerated → review 'git diff tests/fixtures/xmltv_golden.xml' before committing."
 
 test-basic:
 	@chmod +x scripts/test-distribution.bash

--- a/Makefile
+++ b/Makefile
@@ -3,99 +3,81 @@
 
 .PHONY: help clean autofix format lint test-unit tests test-one golden-update test test-basic test-full geodata build install-dev check-deps show-dist all
 
-# Default target
-help:
+# Default target. The target list below is generated from the `## ` comment on
+# each target, so it can never drift out of sync — just add a `## description`
+# when you add a target.
+help:  ## Show this help message
 	@echo "gracenote2epg development Makefile"
 	@echo ""
 	@echo "Available targets:"
-	@echo "  help         Show this help message"
-	@echo "  clean        Clean all build artifacts and caches"
-	@echo "  autofix      Auto-fix imports and common issues with autoflake"
-	@echo "  format       Format code with black"
-	@echo "  lint         Run linting with flake8"
-	@echo "  test-unit    Run unit tests (stdlib unittest, no extra deps)"
-	@echo "  tests        Alias for test-unit"
-	@echo "  test-one     Run one test module: make test-one T=test_worker_pool"
-	@echo "  golden-update Regenerate the XMLTV golden file (after an intended format change)"
-	@echo "  test-basic   Basic functionality test"
-	@echo "  test-full    Full distribution test"
-	@echo "  test         Alias for test-full"
-	@echo "  geodata      Regenerate the bundled postal dataset (run before a release, then commit)"
-	@echo "  build        Build distributions (wheel and source)"
-	@echo "  install-dev  Install in development mode"
-	@echo "  check-deps   Check and install development dependencies"
-	@echo "  show-dist    Show current distribution files"
-	@echo "  all          Run clean, autofix, format, lint, and test-full"
+	@grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "} {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Examples:"
 	@echo "  make clean && make test-basic    # Quick development cycle"
 	@echo "  make autofix format lint         # Code quality pipeline"
+	@echo "  make test-one T=test_worker_pool # Run a single test module"
 	@echo "  make all                         # Complete validation"
-	@echo "  make build && make show-dist     # Build and inspect"
 
 # Development workflow
-clean:
+clean:  ## Clean all build artifacts and caches
 	@chmod +x scripts/dev-helper.bash
 	@./scripts/dev-helper.bash clean
 
-autofix:
+autofix:  ## Auto-fix imports and common issues with autoflake
 	@chmod +x scripts/dev-helper.bash
 	@./scripts/dev-helper.bash autofix
 
-format:
+format:  ## Format code with black
 	@chmod +x scripts/dev-helper.bash
 	@./scripts/dev-helper.bash format
 
-lint:
+lint:  ## Run linting with flake8
 	@chmod +x scripts/dev-helper.bash
 	@./scripts/dev-helper.bash lint
 
-test-unit:
+test-unit:  ## Run unit tests (stdlib unittest, no extra deps)
 	@python3 -m unittest discover -s tests -p "test_*.py" -v
 
-# Alias — `make tests` runs the full stdlib unittest suite.
-tests: test-unit
+tests: test-unit  ## Alias for test-unit
 
-# Run a single test module, e.g. `make test-one T=test_worker_pool`
-# (T may also be a class or method path, e.g. test_worker_pool.WallHandlingTests).
-test-one:
+# T may be a module, class, or method path,
+# e.g. T=test_worker_pool.WallHandlingTests
+test-one:  ## Run one test module: make test-one T=test_worker_pool
 	@python3 -m unittest -v tests.$(T)
 
-# Regenerate the XMLTV golden file after an INTENTIONAL change to the generator's
-# output format; review the diff before committing.
-golden-update:
+golden-update:  ## Regenerate the XMLTV golden file (after an intended format change)
 	@python3 -m tests.test_xmltv_golden --update-golden
 	@echo "Golden regenerated → review 'git diff tests/fixtures/xmltv_golden.xml' before committing."
 
-test-basic:
+test-basic:  ## Basic functionality test
 	@chmod +x scripts/test-distribution.bash
 	@./scripts/test-distribution.bash --basic
 
-test-full:
+test-full:  ## Full distribution test
 	@chmod +x scripts/test-distribution.bash
 	@./scripts/test-distribution.bash --full
 
-test: test-full
+test: test-full  ## Alias for test-full
 
-geodata:
+geodata:  ## Regenerate the bundled postal dataset (run before a release, then commit)
 	@python3 scripts/build-geodata.py
 	@echo "Now review and commit gracenote2epg/data/geopostal.csv.gz"
 
-build:
+build:  ## Build distributions (wheel and source)
 	@python3 -m build
 
-install-dev:
+install-dev:  ## Install in development mode
 	@chmod +x scripts/dev-helper.bash
 	@./scripts/dev-helper.bash install-dev
 
-check-deps:
+check-deps:  ## Check and install development dependencies
 	@chmod +x scripts/dev-helper.bash
 	@./scripts/dev-helper.bash check-deps
 
-show-dist:
+show-dist:  ## Show current distribution files
 	@chmod +x scripts/dev-helper.bash
 	@./scripts/dev-helper.bash show-dist
 
-# Complete workflow with auto-fixes
-all: clean autofix format lint test-unit test-full
+all: clean autofix format lint test-unit test-full  ## Run clean, autofix, format, lint, and all tests
 	@echo "✅ All development tasks completed successfully!"

--- a/docs/development.md
+++ b/docs/development.md
@@ -288,17 +288,21 @@ make clean autofix format lint test-basic
 ### Unit Tests
 
 The suite under `tests/` uses the standard-library `unittest`, so it runs with
-no extra dependencies:
+no extra dependencies. See **[unittesting.md](unittesting.md)** for a per-module
+breakdown of what each test file covers.
 
 ```bash
 # Run the whole suite (no install needed)
-make test-unit
-# or directly
-python3 -m unittest discover -s tests -p "test_*.py" -v
-
+make tests              # alias for: make test-unit
 # Run a single module / case
+make test-one T=test_helpers
+make test-one T=test_helpers.TimezoneOffsetTests
+# Regenerate the XMLTV golden file after an intended format change
+make golden-update
+
+# Or directly, without the Makefile
+python3 -m unittest discover -s tests -p "test_*.py" -v
 python3 -m unittest tests.test_helpers
-python3 -m unittest tests.test_helpers.TimezoneOffsetTests
 
 # Optional: run via pytest if installed (it picks up unittest tests as-is)
 pytest tests/

--- a/docs/unittesting.md
+++ b/docs/unittesting.md
@@ -1,0 +1,104 @@
+# Unit testing
+
+The test suite uses the **Python standard-library `unittest`** — no `pytest`, no
+external dependencies, and **no network access**. Everything (HTTP, the worker
+pool's clock/sleep, randomness) is injected with fakes, so the suite is fast and
+deterministic (122 tests in well under a second).
+
+## Running the tests
+
+```bash
+make tests                       # run the whole suite (alias for test-unit)
+make test-unit                   # same thing, verbose
+make test-one T=test_worker_pool # run a single module
+make test-one T=test_worker_pool.WallHandlingTests          # one class
+make test-one T=test_pacing.RateControllerPacingTests.test_jitter_varies_the_gap  # one test
+```
+
+Without the Makefile:
+
+```bash
+python3 -m unittest discover -s tests -p "test_*.py" -v   # all
+python3 -m unittest -v tests.test_concurrency             # one module
+```
+
+`make all` runs the full quality pipeline (`clean → autofix → format → lint →
+test-unit → test-full`). The CI runs the same `unittest` suite on every push.
+
+## What each test module covers
+
+### Download pacing & the WAF-wall handling
+These cover the adaptive parallel downloader (see
+[configuration.md](configuration.md#download-performance) → `dlworkers` /
+`dlthreshold`).
+
+| Module | Tests | Covers |
+|---|--:|---|
+| `test_pacing.py` | 12 | `RateController`: AIMD rate, per-request **jitter**, the **escalating delay** on a sustained wall (climbs ~`0.8*1.5^failures` → ~15s, resets on success), convergence simulation, and the `DownloadResult`/`TaskMetrics` data types. |
+| `test_concurrency.py` | 5 | `ConcurrencyLimiter` — the **"wave"**: collapse toward 1 worker on a 429, ramp back on a success streak, bounds in-flight, no deadlock. |
+| `test_worker_pool.py` | 16 | `PacedWorkerPool`: every task finalised (no deadlock), keep-alive session reuse, progress, retry of genuine errors, **ride-the-wall** (re-queue 429s, give up only after a long run → `WallHandlingTests`), adaptive-concurrency collapse/recover, save-as-you-go `on_result`. |
+| `test_http.py` | 5 | `execute()` HTTP adapter against a **fake session**: GET vs POST, 429/503/WAF-marker → `rate_limited`, never raises. |
+| `test_download_config.py` | 5 | `get_download_workers()` / `get_download_threshold()` resolution (`auto`, integer overrides, fallbacks). |
+
+### Configuration
+| Module | Tests | Covers |
+|---|--:|---|
+| `test_migration.py` | 4 | Schema migration: a **version-5** config upgrades to the current version and gets the `<imagesources>` block injected (uses `fixtures/config_v5.xml`). |
+| `test_image_source.py` | 10 | The configurable `<imagesources>` block (first `enabled` host wins, parsing, fallbacks). |
+| `test_config_backup_retention.py` | 8 | `reconf` config-backup retention: keep the N most recent **distinct** backups, skip an identical one, `unlimited`/count resolution. |
+| `test_args_validation.py` | 10 | `ArgumentValidator` — CLI argument validation (days range, zip/postal, mutually exclusive flags…). |
+
+### Cache
+| Module | Tests | Covers |
+|---|--:|---|
+| `test_cache_migration.py` | 7 | The `guide/` + `series/` (`SH*`) + `movies/` (`MV*`) cache layout, and automatic migration of older flat / `series/`-only caches. |
+
+### Parsing & XMLTV output
+| Module | Tests | Covers |
+|---|--:|---|
+| `test_series_parser.py` | 8 | `SeriesParser`: crew capture, TV-series credits, per-episode synopsis, display rating, images. |
+| `test_series_application.py` | 3 | Regression: extended details must enrich **every airing** of a series, not just the first. |
+| `test_xmltv_golden.py` | 1 | **Golden-file** regression — see below. |
+
+### Utilities
+| Module | Tests | Covers |
+|---|--:|---|
+| `test_helpers.py` | 11 | Pure helpers in `gracenote2epg.utils` (time/format helpers). |
+| `test_geocoding.py` | 7 | The bundled stdlib postal-code geocoder (no `pgeocode`). |
+| `test_logrotate_periods.py` | 10 | The pure period math extracted into `logrotate.periods`. |
+
+## The golden file (XMLTV output regression)
+
+`test_xmltv_golden.py` feeds a small, fixed parsed schedule (a movie + a TV show)
+through `XmltvGenerator` and compares the output byte-for-byte to a committed
+golden file, `tests/fixtures/xmltv_golden.xml`. The timezone is pinned to UTC so
+the result is stable across machines.
+
+If you **intentionally** change the generated XMLTV format (a new element, an
+attribute, ordering…), the test will fail until you regenerate the golden:
+
+```bash
+make golden-update        # = python3 -m tests.test_xmltv_golden --update-golden
+git diff tests/fixtures/xmltv_golden.xml   # review, then commit
+```
+
+Only regenerate after an *intended* change — an unexpected diff means a
+regression. Most changes (download pacing, logging, retention…) don't touch the
+XMLTV output and leave the golden untouched.
+
+## Fixtures
+
+- `tests/fixtures/config_v5.xml` — a version-5 config, input for the migration test.
+- `tests/fixtures/xmltv_golden.xml` — the expected XMLTV output (above).
+
+> Note: `tests/baseline/` (if present locally) is **not** part of the suite — it
+> is untracked scratch data and is not referenced by any test.
+
+## Conventions for new tests
+
+- One `test_<area>.py` module per area; subclass `unittest.TestCase`.
+- No network and no real sleeping: inject fakes (see `instant_governor` in
+  `test_worker_pool.py`, the `FakeTime` clock in `test_pacing.py`, and the fake
+  session in `test_http.py`).
+- Don't load `tests/baseline/` or any real config in-place — copy to a temp dir
+  first (a `ConfigManager.load_config()` would migrate/rewrite the file).


### PR DESCRIPTION
Follow-up: document the test suite and add convenient Makefile targets.

## Docs
- **`docs/unittesting.md`** — what each of the 16 `tests/` modules covers (grouped: download pacing & WAF-wall handling, config, cache, parsing/XMLTV, utilities), how to run the suite / a single module, the **golden file** (what it is, when/how to regenerate), the fixtures, and conventions for new tests (stdlib `unittest`, no network, inject fakes).
- `docs/development.md` cross-links it and shows the new targets.

## Makefile
- `make tests` — alias for `test-unit` (full stdlib suite).
- `make test-one T=test_worker_pool` — run one module/class/method.
- `make golden-update` — regenerate `tests/fixtures/xmltv_golden.xml` after an intended output change.

Docs + Makefile only — no package code change, so no version bump (stays dev12; independent of #23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
