### PR TITLE
downloader: drop User-Agent rotation, unify on a single UA

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ A modern Python implementation for downloading TV guide data from tvlistings.gra
 
 ## 🌟 Key Features
 
+> 🆕 = new in 2.0
+
 - 📺 **XMLTV standard** - full DTD compliance for broad player/PVR compatibility
-- ⚡ **Adaptive parallel downloads** - self-tuning concurrency that rides the server's rate-limit wall (fast, never blocked)
+- ⚡ **Adaptive parallel downloads** 🆕 - self-tuning concurrency that rides the server's rate-limit wall (fast, never blocked)
+- 🎬 **Rich metadata** 🆕 - cast & crew credits, box-art icons, typed images, per-episode synopsis
+- 🌍 **Built-in geocoding** 🆕 - postal/ZIP → lineup, no `pandas`/`numpy`
 - 🧠 **Intelligent caching** - 95%+ reuse, organized into `guide/`, `series/`, `movies/`
-- 🎬 **Rich metadata** - cast & crew credits, box-art icons, typed images, per-episode synopsis
-- 🌍 **Built-in geocoding** - postal/ZIP → lineup, no `pandas`/`numpy`
 - 🗣️ **Multi-language** - French/English/Spanish detection and translations
 - 📡 **TVheadend integration** - channel filtering and matching
 - ♻️ **Unified retention** - guide cache, logs, XMLTV and config backups

--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ A modern Python implementation for downloading TV guide data from tvlistings.gra
 
 ## 🌟 Key Features
 
-- **XMLTV Standard Compliant** - Full DTD compliance for maximum compatibility
-- **Intelligent Caching** - 95%+ cache efficiency with smart refresh strategies  
-- **Multi-language Support** - Automatic French/English/Spanish detection and translations
-- **TVheadend Integration** - Seamless channel filtering and matching
-- **Unified Cache Management** - Streamlined configuration for all retention policies
-- **Platform Agnostic** - Auto-detection for Raspberry Pi, Synology NAS, and Linux
+- 📺 **XMLTV standard** - full DTD compliance for broad player/PVR compatibility
+- ⚡ **Adaptive parallel downloads** - self-tuning concurrency that rides the server's rate-limit wall (fast, never blocked)
+- 🧠 **Intelligent caching** - 95%+ reuse, organized into `guide/`, `series/`, `movies/`
+- 🎬 **Rich metadata** - cast & crew credits, box-art icons, typed images, per-episode synopsis
+- 🌍 **Built-in geocoding** - postal/ZIP → lineup, no `pandas`/`numpy`
+- 🗣️ **Multi-language** - French/English/Spanish detection and translations
+- 📡 **TVheadend integration** - channel filtering and matching
+- ♻️ **Unified retention** - guide cache, logs, XMLTV and config backups
+- 🧩 **Platform agnostic** - Raspberry Pi, Synology NAS, and Linux
 
 ## 🚀 Installation
 
@@ -28,7 +31,7 @@ pip install gracenote2epg[full]
 pip install gracenote2epg
 
 # Alternative: Install from GitHub
-pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v1.6.1"
+pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev14"
 ```
 
 ### 📦 Development Installation

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ All notable changes to gracenote2epg are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - Unreleased
+## [2.0.0-dev14] - 2026-06-17
 
 Major maintainability refactor: the monolithic modules were split into focused
 packages (`config/`, `args/`, `parser/`, `downloader/`, `xmltv/`, `logrotate/`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -83,6 +83,11 @@ with no change to the generated guide.
 - **`--basedir`**: now honoured for the config, cache, log and XMLTV locations.
 
 ### Changed
+- **Single User-Agent everywhere**: the sequential engine's 5-entry User-Agent
+  rotation is removed — both download paths now use the one stable browser-like
+  UA already used by the parallel pool. Rotation was unnecessary (a single UA
+  sustains hundreds of requests) and useless against the WAF, which gates by
+  request volume, not identity.
 - **Download/retention logging**: parallel downloads now trace each item with
   its id and an `x/y` counter (e.g. `Extended details: SH… (377/1347)`,
   `Guide block: …`), the per-request adaptive delay names the item it paces, the

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,10 +24,10 @@ pip install gracenote2epg[translations]  # Translation support only
 #### Latest Stable Release
 ```bash
 # Install latest stable release from GitHub
-pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.5"
+pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev14"
 
 # Basic installation from GitHub
-pip install "gracenote2epg @ git+https://github.com/th0ma7/gracenote2epg.git@v1.5.5"
+pip install "gracenote2epg @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev14"
 ```
 
 #### Latest Development Version
@@ -51,13 +51,13 @@ pip install .        # Basic installation
 ### Method 4: Manual Installation (Source Distribution)
 ```bash
 # Download source from GitHub releases
-wget https://github.com/th0ma7/gracenote2epg/archive/v1.5.5.tar.gz -O gracenote2epg-1.5.5.tar.gz
+wget https://github.com/th0ma7/gracenote2epg/archive/v2.0.0-dev14.tar.gz -O gracenote2epg-2.0.0-dev14.tar.gz
 
 # Install into /usr/local/
-sudo tar -xzf gracenote2epg-1.5.5.tar.gz -C /usr/local/
+sudo tar -xzf gracenote2epg-2.0.0-dev14.tar.gz -C /usr/local/
 
 # Create a generic gracenote2epg symbolic link
-sudo ln -sf /usr/local/gracenote2epg-1.5.5 /usr/local/gracenote2epg
+sudo ln -sf /usr/local/gracenote2epg-2.0.0-dev14 /usr/local/gracenote2epg
 
 # Make tv_grab_gracenote2epg available in /usr/local/bin
 sudo ln -sf /usr/local/gracenote2epg/tv_grab_gracenote2epg /usr/local/bin
@@ -120,7 +120,7 @@ tv_grab_gracenote2epg --version
 sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install gracenote2epg[full]'
 
 # Install a specific version of gracenote2epg from Pypi in TVheadend environment
-sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full]==1.5.5"'
+sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full]==2.0.0-dev14"'
 
 # Install latest git snapshot
 sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git"'
@@ -169,7 +169,7 @@ python -m gracenote2epg --version    # Module execution
 ```bash
 # Check if package is installed
 pip list | grep gracenote2epg
-# Expected output: gracenote2epg    1.5.5
+# Expected output: gracenote2epg    2.0.0-dev14
 
 # Check version
 tv_grab_gracenote2epg --version

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev13"
+__version__ = "2.0.0-dev14"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/downloader/base.py
+++ b/gracenote2epg/downloader/base.py
@@ -16,6 +16,8 @@ from typing import Optional, Dict, Any
 
 import requests
 from requests.adapters import HTTPAdapter
+
+from .http import USER_AGENT
 from urllib3.util.retry import Retry
 import urllib3
 
@@ -25,13 +27,6 @@ class OptimizedDownloader:
 
     def __init__(self, base_delay: float = 1.0, min_delay: float = 0.5):
         self.session: Optional[requests.Session] = None
-        self.user_agents = [
-            "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0",
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0",
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15",
-        ]
         self.last_request_time = 0
         self.base_delay = base_delay
         self.min_delay = min_delay
@@ -39,7 +34,6 @@ class OptimizedDownloader:
         self.consecutive_failures = 0
         self.waf_blocks = 0
         self.total_requests = 0
-        self.current_ua_index = 0
 
         # Initialize session
         self.init_session()
@@ -53,6 +47,7 @@ class OptimizedDownloader:
 
         # Realistic headers with forced Keep-Alive
         base_headers = {
+            "User-Agent": USER_AGENT,
             "Accept": "application/json, text/html, application/xhtml+xml, */*",
             "Accept-Language": "en-US,en;q=0.9,fr;q=0.8",
             "Accept-Encoding": "gzip, deflate, br",
@@ -82,16 +77,7 @@ class OptimizedDownloader:
         # Configure urllib3 for persistence
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-        # Set initial User-Agent
-        self.rotate_user_agent()
         logging.debug("HTTP engine initialized with persistent connections")
-
-    def rotate_user_agent(self):
-        """Rotate User-Agent intelligently"""
-        self.current_ua_index = (self.current_ua_index + 1) % len(self.user_agents)
-        new_ua = self.user_agents[self.current_ua_index]
-        self.session.headers.update({"User-Agent": new_ua})
-        logging.debug("  User-Agent rotated: %s", new_ua[:50] + "...")
 
     def adaptive_delay(self):
         """Apply adaptive delay between requests"""
@@ -135,8 +121,6 @@ class OptimizedDownloader:
         extra_delay = random.uniform(*extra_delay_range)
         logging.warning("  WAF block detected, backing off %.1fs...", extra_delay)
         time.sleep(extra_delay)
-        if self.total_requests % 10 == 0:  # Rotate occasionally after blocks
-            self.rotate_user_agent()
 
     def download_with_retry_urllib(
         self,
@@ -157,15 +141,10 @@ class OptimizedDownloader:
             else:
                 timeout = 15  # Longer if repeated problems
 
-        # Periodic User-Agent rotation
-        if self.total_requests % 25 == 0:
-            self.rotate_user_agent()
-
         for attempt in range(max_retries):
             self.adaptive_delay()
 
             current_timeout = timeout + (attempt * 2)  # Increase timeout on each retry
-            current_ua = self.user_agents[self.current_ua_index]
 
             # Build display URL with parameters
             if data:
@@ -184,7 +163,7 @@ class OptimizedDownloader:
             try:
                 # Use urllib exactly like the original working version
                 url_request = urllib.request.Request(
-                    url, data=data, headers={"User-Agent": current_ua}
+                    url, data=data, headers={"User-Agent": USER_AGENT}
                 )
                 json_content = urllib.request.urlopen(url_request, timeout=current_timeout).read()
 
@@ -251,10 +230,6 @@ class OptimizedDownloader:
                 timeout = 10  # Medium after 1 failure
             else:
                 timeout = 15  # Longer if repeated problems
-
-        # Periodic User-Agent rotation
-        if self.total_requests % 25 == 0:
-            self.rotate_user_agent()
 
         for attempt in range(max_retries):
             self.adaptive_delay()


### PR DESCRIPTION
Your call — unify the User-Agent handling.

The parallel pool already uses **one stable UA** (rotation proved unnecessary). The sequential engine (`OptimizedDownloader`) still carried a 5-entry rotation list + `rotate_user_agent()` rotating periodically (every 10/25 requests, after blocks). In `auto` mode that path isn't even used, so it was effectively dead, and — proven on your NAS — the WAF gates by **request volume, not identity**, so rotating UA never helped reopen the wall.

## Change
- Remove the UA list, `current_ua_index`, `rotate_user_agent()` and every call site.
- Import the single `USER_AGENT` from `downloader/http.py` (one source of truth) and set it once in the session headers; the urllib path uses the same constant.
- Both download paths now send the identical, stable Firefox UA.

No behaviour change for the common `auto` path (it already used a single UA); this just unifies the sequential path and drops dead complexity.

122 tests green, `black`/`flake8` clean. Version → **dev14**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
