### PR TITLE
logging: trim INFO noise, unify progress at 20% (dev15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install gracenote2epg[full]
 pip install gracenote2epg
 
 # Alternative: Install from GitHub
-pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev14"
+pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev15"
 ```
 
 ### 📦 Development Installation

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ All notable changes to gracenote2epg are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0-dev14] - 2026-06-17
+## [2.0.0-dev15] - 2026-06-17
 
 Major maintainability refactor: the monolithic modules were split into focused
 packages (`config/`, `args/`, `parser/`, `downloader/`, `xmltv/`, `logrotate/`)
@@ -83,6 +83,11 @@ with no change to the generated guide.
 - **`--basedir`**: now honoured for the config, cache, log and XMLTV locations.
 
 ### Changed
+- **Cleaner run logs**: the redundant `Caching directory` line, the raw guide-start
+  epoch, repeated per-airing `TBA` notices and the startup log-rotation analysis
+  moved to `DEBUG`; guide, series-details and XMLTV-generation progress now log
+  every 20% (instead of every 5%); and the language summary is labelled
+  `detections` (title+description lookups) rather than `episodes`.
 - **Single User-Agent everywhere**: the sequential engine's 5-entry User-Agent
   rotation is removed — both download paths now use the one stable browser-like
   UA already used by the parallel pool. Rotation was unnecessary (a single UA

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,10 +24,10 @@ pip install gracenote2epg[translations]  # Translation support only
 #### Latest Stable Release
 ```bash
 # Install latest stable release from GitHub
-pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev14"
+pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev15"
 
 # Basic installation from GitHub
-pip install "gracenote2epg @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev14"
+pip install "gracenote2epg @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev15"
 ```
 
 #### Latest Development Version
@@ -51,13 +51,13 @@ pip install .        # Basic installation
 ### Method 4: Manual Installation (Source Distribution)
 ```bash
 # Download source from GitHub releases
-wget https://github.com/th0ma7/gracenote2epg/archive/v2.0.0-dev14.tar.gz -O gracenote2epg-2.0.0-dev14.tar.gz
+wget https://github.com/th0ma7/gracenote2epg/archive/v2.0.0-dev15.tar.gz -O gracenote2epg-2.0.0-dev15.tar.gz
 
 # Install into /usr/local/
-sudo tar -xzf gracenote2epg-2.0.0-dev14.tar.gz -C /usr/local/
+sudo tar -xzf gracenote2epg-2.0.0-dev15.tar.gz -C /usr/local/
 
 # Create a generic gracenote2epg symbolic link
-sudo ln -sf /usr/local/gracenote2epg-2.0.0-dev14 /usr/local/gracenote2epg
+sudo ln -sf /usr/local/gracenote2epg-2.0.0-dev15 /usr/local/gracenote2epg
 
 # Make tv_grab_gracenote2epg available in /usr/local/bin
 sudo ln -sf /usr/local/gracenote2epg/tv_grab_gracenote2epg /usr/local/bin
@@ -120,7 +120,7 @@ tv_grab_gracenote2epg --version
 sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install gracenote2epg[full]'
 
 # Install a specific version of gracenote2epg from Pypi in TVheadend environment
-sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full]==2.0.0-dev14"'
+sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full]==2.0.0-dev15"'
 
 # Install latest git snapshot
 sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git"'
@@ -169,7 +169,7 @@ python -m gracenote2epg --version    # Module execution
 ```bash
 # Check if package is installed
 pip list | grep gracenote2epg
-# Expected output: gracenote2epg    2.0.0-dev14
+# Expected output: gracenote2epg    2.0.0-dev15
 
 # Check version
 tv_grab_gracenote2epg --version

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev14"
+__version__ = "2.0.0-dev15"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/downloader/guide.py
+++ b/gracenote2epg/downloader/guide.py
@@ -153,6 +153,8 @@ class GuideDownloader(DownloaderStatsMixin):
                     note = " [failed]"
                 idx = self.downloaded_count + self.cached_count + self.failed_count
             logging.debug("  Guide block: %s (%d/%d)%s", result.task_id, idx, total, note)
+            if idx == 1 or idx % max(1, total // 5) == 0 or idx == total:
+                logging.info("  Guide blocks: %d/%d", idx, total)
 
         pool = PacedWorkerPool(
             execute, workers=workers, session_factory=make_session, on_result=on_result

--- a/gracenote2epg/downloader/guide.py
+++ b/gracenote2epg/downloader/guide.py
@@ -98,7 +98,7 @@ class GuideDownloader(DownloaderStatsMixin):
         """Fetch the blocks that need it concurrently (keep-alive worker pool)."""
         from .http import make_session, execute
         from .tasks import DownloadTask
-        from .worker_pool import PacedWorkerPool
+        from .worker_pool import PacedWorkerPool, log_progress
 
         # Decide per block: cached / fetch / missing (no network here).
         to_fetch = []  # (filename, was_existing)
@@ -153,8 +153,7 @@ class GuideDownloader(DownloaderStatsMixin):
                     note = " [failed]"
                 idx = self.downloaded_count + self.cached_count + self.failed_count
             logging.debug("  Guide block: %s (%d/%d)%s", result.task_id, idx, total, note)
-            if idx == 1 or idx % max(1, total // 5) == 0 or idx == total:
-                logging.info("  Guide blocks: %d/%d", idx, total)
+            log_progress("Guide blocks", idx, total)
 
         pool = PacedWorkerPool(
             execute, workers=workers, session_factory=make_session, on_result=on_result

--- a/gracenote2epg/downloader/series.py
+++ b/gracenote2epg/downloader/series.py
@@ -143,7 +143,7 @@ class SeriesDownloader(DownloaderStatsMixin):
                 total,
                 "" if saved else " [failed]",
             )
-            if idx == 1 or idx % max(1, total // 10) == 0 or idx == total:
+            if idx == 1 or idx % max(1, total // 5) == 0 or idx == total:
                 logging.info("  Extended details: %d/%d", idx, total)
 
         tasks = [

--- a/gracenote2epg/downloader/series.py
+++ b/gracenote2epg/downloader/series.py
@@ -114,7 +114,7 @@ class SeriesDownloader(DownloaderStatsMixin):
 
         from .http import make_session, execute
         from .tasks import DownloadTask
-        from .worker_pool import PacedWorkerPool
+        from .worker_pool import PacedWorkerPool, log_progress
 
         total = len(to_download)
         tally_lock = threading.Lock()
@@ -143,8 +143,7 @@ class SeriesDownloader(DownloaderStatsMixin):
                 total,
                 "" if saved else " [failed]",
             )
-            if idx == 1 or idx % max(1, total // 5) == 0 or idx == total:
-                logging.info("  Extended details: %d/%d", idx, total)
+            log_progress("Extended details", idx, total)
 
         tasks = [
             DownloadTask(

--- a/gracenote2epg/downloader/worker_pool.py
+++ b/gracenote2epg/downloader/worker_pool.py
@@ -43,6 +43,15 @@ ProgressFn = Callable[[int, int], None]
 ResultFn = Callable[[DownloadResult], None]
 
 
+def log_progress(label: str, done: int, total: int, step: int = 5) -> None:
+    """Log an INFO progress line at the first, last, and every 1/step item.
+
+    ``step=5`` -> every 20%. Shared by the guide and series downloaders.
+    """
+    if done == 1 or done == total or done % max(1, total // step) == 0:
+        logging.info("  %s: %d/%d", label, done, total)
+
+
 class PacedWorkerPool:
     """Run download tasks across a fixed pool of keep-alive workers."""
 

--- a/gracenote2epg/language.py
+++ b/gracenote2epg/language.py
@@ -389,7 +389,7 @@ class LanguageDetector:
                 for lang, count in self.language_stats.items():
                     percentage = (count / total_episodes) * 100
                     lang_name = {"fr": "French", "en": "English", "es": "Spanish"}[lang]
-                    logging.info("  %s: %d episodes (%.1f%%)", lang_name, count, percentage)
+                    logging.info("  %s: %d detections (%.1f%%)", lang_name, count, percentage)
 
                 # Cache performance statistics
                 cache_stats = self.get_cache_stats()

--- a/gracenote2epg/logrotate/handler.py
+++ b/gracenote2epg/logrotate/handler.py
@@ -199,18 +199,17 @@ class CopyTruncateTimedRotatingFileHandler(logging.handlers.BaseRotatingHandler)
             complete_periods = [p for p, data in periods_data.items() if data["complete"]]
             current_periods = [p for p, data in periods_data.items() if not data["complete"]]
 
-            logging.info("Log analysis complete (%s rotation):", self.period_name)
-            logging.info(
-                "  Complete %ss found: %d (%s)",
+            logging.debug("Log analysis complete (%s rotation):", self.period_name)
+            logging.debug(
+                "  Complete %s periods found: %d (%s)",
                 self.period_name,
                 len(complete_periods),
-                ", ".join(complete_periods),
+                ", ".join(complete_periods) if complete_periods else "none",
             )
-            logging.info(
-                "  Current %s: %s (%s)",
+            logging.debug(
+                "  Current %s period: %s (stays in the current log)",
                 self.period_name,
                 ", ".join(current_periods) if current_periods else "none",
-                "will remain in current log",
             )
 
             return periods_data

--- a/gracenote2epg/main.py
+++ b/gracenote2epg/main.py
@@ -244,9 +244,9 @@ def main():
             file_handler, "_check_startup_rotation"
         ):
             try:
-                logging.info("Checking for startup log rotation...")
+                logging.debug("Checking for startup log rotation...")
                 file_handler._check_startup_rotation()
-                logging.info("Startup rotation check completed")
+                logging.debug("Startup rotation check completed")
             except Exception as e:
                 logging.warning("Error during startup rotation check: %s", str(e))
 
@@ -315,13 +315,11 @@ def main():
         logging.info("TV Guide duration: %s days", days)
 
         if offset > 1:
-            logging.info("TV Guide Start: %i [offset: %i days]", grid_time_start, int(offset))
+            logging.debug("TV Guide Start: %i [offset: %i days]", grid_time_start, int(offset))
         elif offset == 1:
-            logging.info("TV Guide Start: %i [offset: %i day]", grid_time_start, int(offset))
+            logging.debug("TV Guide Start: %i [offset: %i day]", grid_time_start, int(offset))
         else:
-            logging.info("TV Guide Start: %i", grid_time_start)
-
-        logging.info("Caching directory: %s", defaults["cache_dir"])
+            logging.debug("TV Guide Start: %i", grid_time_start)
 
         # Log cache refresh configuration
         if refresh_hours == 0:

--- a/gracenote2epg/parser/series.py
+++ b/gracenote2epg/parser/series.py
@@ -181,7 +181,7 @@ class SeriesParser:
         try:
             episode_title = airing.get("episodeTitle", "")
             if episode_title and "TBA" in episode_title:
-                logging.info("Found TBA listing in series %s: %s", series_id, episode_title)
+                logging.debug("Found TBA listing in series %s: %s", series_id, episode_title)
         except Exception:
             pass
 

--- a/gracenote2epg/xmltv/programme.py
+++ b/gracenote2epg/xmltv/programme.py
@@ -47,7 +47,7 @@ class ProgrammeMixin:
             # Progress tracking variables
             processed_episodes = 0
             last_progress_log = 0
-            progress_interval = max(1, total_episodes // 20)  # Log every 5% (20 intervals)
+            progress_interval = max(1, total_episodes // 5)  # Log every 20% (5 intervals)
 
             for station_id, station_data in schedule.items():
                 for episode_key, episode_data in station_data.items():
@@ -62,7 +62,7 @@ class ProgrammeMixin:
 
                         # Log progress
                         if (
-                            processed_episodes - last_progress_log >= min(progress_interval, 1000)
+                            processed_episodes - last_progress_log >= progress_interval
                             or processed_episodes == total_episodes
                         ):
                             progress_percent = (

--- a/tests/test_worker_pool.py
+++ b/tests/test_worker_pool.py
@@ -4,7 +4,7 @@ import threading
 import unittest
 
 from gracenote2epg.downloader.pacing import RateController
-from gracenote2epg.downloader.worker_pool import PacedWorkerPool
+from gracenote2epg.downloader.worker_pool import PacedWorkerPool, log_progress
 from gracenote2epg.downloader.tasks import DownloadResult, DownloadTask
 
 
@@ -293,6 +293,21 @@ class OnResultTests(unittest.TestCase):
         )
         pool.run(tasks(30))
         self.assertEqual(sorted(seen, key=int), [str(i) for i in range(30)])
+
+
+class LogProgressTests(unittest.TestCase):
+    def _logged_counts(self, total, step=5):
+        with self.assertLogs(level="INFO") as cm:
+            for done in range(1, total + 1):
+                log_progress("X", done, total, step=step)
+        return sorted({int(r.split("X: ")[1].split("/")[0]) for r in cm.output if "X: " in r})
+
+    def test_logs_first_last_and_every_20_percent(self):
+        # total=10, step=5 -> every 2; plus the first (1) and last (10).
+        self.assertEqual(self._logged_counts(10), [1, 2, 4, 6, 8, 10])
+
+    def test_small_total_still_logs_first_and_last(self):
+        self.assertEqual(self._logged_counts(3), [1, 2, 3])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
From reviewing a normal run log — quieter, less redundant INFO output. No behaviour/output change (golden XMLTV unchanged).

## INFO trimmed / demoted to DEBUG
- **Removed** the duplicate `Caching directory:` line (the path is already in the `Locations` block).
- **→ DEBUG**: the raw `TV Guide Start: <epoch>` (unreadable number), the repeated per-airing `Found TBA listing …`, and the startup log-rotation analysis (`Log analysis complete … / Complete dailys found: 0 ()` — also fixed its grammar and empty parens).

## Progress unified at every 20%
- **Guide blocks**, **series details** and **XMLTV generation** now log progress every 20% (5 lines) instead of every 5% (≈20 lines). Guide downloads gained an INFO progress line (was DEBUG-only).

## Accuracy
- The language summary now says `detections` (title+description lookups) instead of `episodes` — the count was lookups, not episodes (the sum exceeded the episode total).

Version + doc version pins bumped `2.0.0-dev14 → dev15`. 122 tests green, black/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
