### PR TITLE
logging: faster startup rotation + fix guide progress count + drop redundant line (dev16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install gracenote2epg[full]
 pip install gracenote2epg
 
 # Alternative: Install from GitHub
-pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev15"
+pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev16"
 ```
 
 ### 📦 Development Installation

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ All notable changes to gracenote2epg are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0-dev15] - 2026-06-17
+## [2.0.0-dev16] - 2026-06-17
 
 Major maintainability refactor: the monolithic modules were split into focused
 packages (`config/`, `args/`, `parser/`, `downloader/`, `xmltv/`, `logrotate/`)
@@ -56,6 +56,10 @@ with no change to the generated guide.
   schema → 8.
 
 ### Fixed
+- **Guide download progress count**: the progress line showed an impossible
+  ratio like `Guide blocks: 96/18` (the running total of *all* blocks against the
+  *fetched* count). It now counts only the blocks actually being downloaded, e.g.
+  `Guide blocks: 4/18`.
 - **Never overwrite a good guide with an empty one**: if the guide download
   returns no programmes at all (e.g. the server rate-limits every block), the
   run now keeps the existing `xmltv.xml` and exits with an error instead of
@@ -83,11 +87,17 @@ with no change to the generated guide.
 - **`--basedir`**: now honoured for the config, cache, log and XMLTV locations.
 
 ### Changed
-- **Cleaner run logs**: the redundant `Caching directory` line, the raw guide-start
-  epoch, repeated per-airing `TBA` notices and the startup log-rotation analysis
-  moved to `DEBUG`; guide, series-details and XMLTV-generation progress now log
-  every 20% (instead of every 5%); and the language summary is labelled
-  `detections` (title+description lookups) rather than `episodes`.
+- **Cleaner run logs**: the redundant `Caching directory` and `Configuration
+  loaded from` lines (both already shown in the startup `Locations` block), the
+  raw guide-start epoch, repeated per-airing `TBA` notices and the startup
+  log-rotation analysis moved to `DEBUG`; guide, series-details and
+  XMLTV-generation progress now log every 20% (instead of every 5%); and the
+  language summary is labelled `detections` (title+description lookups) rather
+  than `episodes`.
+- **Faster startup log-rotation check**: instead of reading the whole log on
+  every run, the catch-up check first reads just the first line — if the log is
+  already within the current rotation period there is nothing to rotate and the
+  full scan is skipped entirely (a big speedup with large DEBUG logs).
 - **Single User-Agent everywhere**: the sequential engine's 5-entry User-Agent
   rotation is removed — both download paths now use the one stable browser-like
   UA already used by the parallel pool. Rotation was unnecessary (a single UA

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,10 +24,10 @@ pip install gracenote2epg[translations]  # Translation support only
 #### Latest Stable Release
 ```bash
 # Install latest stable release from GitHub
-pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev15"
+pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev16"
 
 # Basic installation from GitHub
-pip install "gracenote2epg @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev15"
+pip install "gracenote2epg @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev16"
 ```
 
 #### Latest Development Version
@@ -51,13 +51,13 @@ pip install .        # Basic installation
 ### Method 4: Manual Installation (Source Distribution)
 ```bash
 # Download source from GitHub releases
-wget https://github.com/th0ma7/gracenote2epg/archive/v2.0.0-dev15.tar.gz -O gracenote2epg-2.0.0-dev15.tar.gz
+wget https://github.com/th0ma7/gracenote2epg/archive/v2.0.0-dev16.tar.gz -O gracenote2epg-2.0.0-dev16.tar.gz
 
 # Install into /usr/local/
-sudo tar -xzf gracenote2epg-2.0.0-dev15.tar.gz -C /usr/local/
+sudo tar -xzf gracenote2epg-2.0.0-dev16.tar.gz -C /usr/local/
 
 # Create a generic gracenote2epg symbolic link
-sudo ln -sf /usr/local/gracenote2epg-2.0.0-dev15 /usr/local/gracenote2epg
+sudo ln -sf /usr/local/gracenote2epg-2.0.0-dev16 /usr/local/gracenote2epg
 
 # Make tv_grab_gracenote2epg available in /usr/local/bin
 sudo ln -sf /usr/local/gracenote2epg/tv_grab_gracenote2epg /usr/local/bin
@@ -120,7 +120,7 @@ tv_grab_gracenote2epg --version
 sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install gracenote2epg[full]'
 
 # Install a specific version of gracenote2epg from Pypi in TVheadend environment
-sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full]==2.0.0-dev15"'
+sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full]==2.0.0-dev16"'
 
 # Install latest git snapshot
 sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git"'
@@ -169,7 +169,7 @@ python -m gracenote2epg --version    # Module execution
 ```bash
 # Check if package is installed
 pip list | grep gracenote2epg
-# Expected output: gracenote2epg    2.0.0-dev15
+# Expected output: gracenote2epg    2.0.0-dev16
 
 # Check version
 tv_grab_gracenote2epg --version

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev15"
+__version__ = "2.0.0-dev16"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/downloader/guide.py
+++ b/gracenote2epg/downloader/guide.py
@@ -130,11 +130,13 @@ class GuideDownloader(DownloaderStatsMixin):
         import threading
 
         existed_map = dict(to_fetch)
-        total = len(tasks)
+        total = len(tasks)  # blocks actually being fetched (cached ones aren't here)
         tally_lock = threading.Lock()
+        fetched = 0  # progress is over the fetched blocks, not the whole guide
 
         def on_result(result) -> None:
             # Runs as each block finalises (save-as-you-go).
+            nonlocal fetched
             saved = False
             if result.success and result.content:
                 saved = self.cache_manager.validate_and_save_guide_block(
@@ -151,7 +153,8 @@ class GuideDownloader(DownloaderStatsMixin):
                 else:
                     self.failed_count += 1
                     note = " [failed]"
-                idx = self.downloaded_count + self.cached_count + self.failed_count
+                fetched += 1
+                idx = fetched
             logging.debug("  Guide block: %s (%d/%d)%s", result.task_id, idx, total, note)
             log_progress("Guide blocks", idx, total)
 

--- a/gracenote2epg/logrotate/handler.py
+++ b/gracenote2epg/logrotate/handler.py
@@ -99,7 +99,23 @@ class CopyTruncateTimedRotatingFileHandler(logging.handlers.BaseRotatingHandler)
             return
 
         try:
-            # Analyze log file and group entries by periods (daily/weekly/monthly)
+            # Fast path: if the log's first entry already belongs to the current
+            # period, the whole file is within it and there is nothing to rotate.
+            # This reads only the first line instead of scanning the entire
+            # (possibly huge) log on every startup.
+            first_dt = self._first_entry_datetime(log_file)
+            if first_dt is not None:
+                first_suffix = self._get_period_info(first_dt)[2]
+                current_suffix = self._get_period_info(datetime.now())[2]
+                if first_suffix == current_suffix:
+                    logging.debug(
+                        "Log is within the current %s period (%s) - no rotation needed",
+                        self.period_name,
+                        current_suffix,
+                    )
+                    return
+
+            # A previous period exists -> full analysis + rotation (reads the file).
             periods_data = self._analyze_log_periods(log_file)
             if periods_data:
                 self._perform_multi_period_rotation(periods_data)
@@ -108,6 +124,26 @@ class CopyTruncateTimedRotatingFileHandler(logging.handlers.BaseRotatingHandler)
 
         except Exception as e:
             logging.warning("Error during startup rotation check: %s", str(e))
+
+    @staticmethod
+    def _first_entry_datetime(log_file: Path) -> Optional[datetime]:
+        """Timestamp of the first log entry, reading only the first lines (cheap).
+
+        Avoids loading the whole file just to decide whether rotation is due.
+        Skips leading separator/blank lines; returns None if no entry is found.
+        """
+        try:
+            with open(log_file, "r", encoding="utf-8", errors="ignore") as f:
+                for _ in range(50):  # the first real entry is near the top
+                    line = f.readline()
+                    if not line:
+                        break
+                    match = re.match(r"^(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2})", line)
+                    if match:
+                        return datetime.strptime(match.group(1), "%Y/%m/%d %H:%M:%S")
+        except OSError:
+            pass
+        return None
 
     def _analyze_log_periods(self, log_file: Path) -> Dict[str, Dict]:
         """

--- a/gracenote2epg/main.py
+++ b/gracenote2epg/main.py
@@ -272,8 +272,8 @@ def main():
         # Log command line processing BEFORE config summary
         log_command_line_processing(args)
 
-        # Log configuration summary
-        logging.info("Configuration loaded from: %s", config_file)
+        # Log configuration summary (the path is already shown in the Locations block)
+        logging.debug("Configuration loaded from: %s", config_file)
         config_manager.log_config_summary()
 
         # Initialize components with new architecture

--- a/tests/test_logrotate_periods.py
+++ b/tests/test_logrotate_periods.py
@@ -1,9 +1,12 @@
 """Unit tests for the pure period math extracted into logrotate.periods."""
 
+import tempfile
 import unittest
 from datetime import datetime
+from pathlib import Path
 
 from gracenote2epg.logrotate import periods
+from gracenote2epg.logrotate.handler import CopyTruncateTimedRotatingFileHandler as Handler
 
 
 class WeekStartTests(unittest.TestCase):
@@ -66,6 +69,28 @@ class NextRolloverTests(unittest.TestCase):
         before = time.time()
         nr = periods.next_rollover_at("HOURLY", 3600)
         self.assertGreaterEqual(nr, before + 3600 - 1)
+
+
+class FirstEntryDatetimeTests(unittest.TestCase):
+    """The cheap first-line read used to skip the full scan when nothing rotates."""
+
+    def _write(self, text):
+        p = Path(tempfile.mkdtemp()) / "gracenote2epg.log"
+        p.write_text(text)
+        return p
+
+    def test_reads_first_timestamp_skipping_separators(self):
+        p = self._write(
+            "============\n\n2026/06/16 20:54:19 INFO  started\n2026/06/17 01:00:00 INFO later\n"
+        )
+        self.assertEqual(Handler._first_entry_datetime(p), datetime(2026, 6, 16, 20, 54, 19))
+
+    def test_none_when_no_timestamped_line(self):
+        p = self._write("just a banner\nno timestamps here\n")
+        self.assertIsNone(Handler._first_entry_datetime(p))
+
+    def test_none_when_file_missing(self):
+        self.assertIsNone(Handler._first_entry_datetime(Path("/no/such/file.log")))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Three follow-ups from your latest dev15 run.

## 1. Faster startup log-rotation check (your idea: head/tail)
`_analyze_log_periods` did a full `readlines()` of the log on **every** startup — extremely slow with large DEBUG logs. Now the catch-up check first reads **just the first line**: if its timestamp is already in the current rotation period, the whole file belongs to it, there's nothing to rotate, and the full scan is **skipped**. The expensive scan only runs when a previous period actually exists (i.e. rotation is genuinely due). New static `_first_entry_datetime()` + unit tests.

## 2. Fix the guide progress count
The progress line showed an impossible `Guide blocks: 96/18` — the numerator was the running total of *all* 112 blocks (including the 94 already-cached, pre-counted) while the denominator was only the 18 being fetched. It now counts only the blocks actually being downloaded → `Guide blocks: 4/18`. (Series details was already correct; with a small batch the 20% step shows each item, which is expected.)

## 3. Drop a redundant log line
`Configuration loaded from: …` → DEBUG: the path is already in the startup `Locations` block (same rationale as the `Caching directory` removal).

Version + doc pins → **dev16**. 127 tests green, black/flake8 (tightened) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
