### PR TITLE
release: 2.0.0 (final)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install gracenote2epg[full]
 pip install gracenote2epg
 
 # Alternative: Install from GitHub
-pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev16"
+pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0"
 ```
 
 ### 📦 Development Installation

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ All notable changes to gracenote2epg are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0-dev16] - 2026-06-17
+## [2.0.0] - 2026-06-17
 
 Major maintainability refactor: the monolithic modules were split into focused
 packages (`config/`, `args/`, `parser/`, `downloader/`, `xmltv/`, `logrotate/`)
@@ -91,9 +91,10 @@ with no change to the generated guide.
   loaded from` lines (both already shown in the startup `Locations` block), the
   raw guide-start epoch, repeated per-airing `TBA` notices and the startup
   log-rotation analysis moved to `DEBUG`; guide, series-details and
-  XMLTV-generation progress now log every 20% (instead of every 5%); and the
+  XMLTV-generation progress now log every 20% (instead of every 5%); the
   language summary is labelled `detections` (title+description lookups) rather
-  than `episodes`.
+  than `episodes`; and the guide/extended-details "had issues" warning is no
+  longer logged twice.
 - **Faster startup log-rotation check**: instead of reading the whole log on
   every run, the catch-up check first reads just the first line — if the log is
   already within the current rotation period there is nothing to rotate and the

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,10 +24,10 @@ pip install gracenote2epg[translations]  # Translation support only
 #### Latest Stable Release
 ```bash
 # Install latest stable release from GitHub
-pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev16"
+pip install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0"
 
 # Basic installation from GitHub
-pip install "gracenote2epg @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0-dev16"
+pip install "gracenote2epg @ git+https://github.com/th0ma7/gracenote2epg.git@v2.0.0"
 ```
 
 #### Latest Development Version
@@ -51,13 +51,13 @@ pip install .        # Basic installation
 ### Method 4: Manual Installation (Source Distribution)
 ```bash
 # Download source from GitHub releases
-wget https://github.com/th0ma7/gracenote2epg/archive/v2.0.0-dev16.tar.gz -O gracenote2epg-2.0.0-dev16.tar.gz
+wget https://github.com/th0ma7/gracenote2epg/archive/v2.0.0.tar.gz -O gracenote2epg-2.0.0.tar.gz
 
 # Install into /usr/local/
-sudo tar -xzf gracenote2epg-2.0.0-dev16.tar.gz -C /usr/local/
+sudo tar -xzf gracenote2epg-2.0.0.tar.gz -C /usr/local/
 
 # Create a generic gracenote2epg symbolic link
-sudo ln -sf /usr/local/gracenote2epg-2.0.0-dev16 /usr/local/gracenote2epg
+sudo ln -sf /usr/local/gracenote2epg-2.0.0 /usr/local/gracenote2epg
 
 # Make tv_grab_gracenote2epg available in /usr/local/bin
 sudo ln -sf /usr/local/gracenote2epg/tv_grab_gracenote2epg /usr/local/bin
@@ -120,7 +120,7 @@ tv_grab_gracenote2epg --version
 sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install gracenote2epg[full]'
 
 # Install a specific version of gracenote2epg from Pypi in TVheadend environment
-sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full]==2.0.0-dev16"'
+sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full]==2.0.0"'
 
 # Install latest git snapshot
 sudo su -s /bin/bash sc-tvheadend -c '/var/packages/tvheadend/target/env/bin/pip3 install "gracenote2epg[full] @ git+https://github.com/th0ma7/gracenote2epg.git"'
@@ -169,7 +169,7 @@ python -m gracenote2epg --version    # Module execution
 ```bash
 # Check if package is installed
 pip list | grep gracenote2epg
-# Expected output: gracenote2epg    2.0.0-dev16
+# Expected output: gracenote2epg    2.0.0
 
 # Check version
 tv_grab_gracenote2epg --version

--- a/gracenote2epg/__init__.py
+++ b/gracenote2epg/__init__.py
@@ -5,7 +5,7 @@ A modular Python implementation for downloading TV guide data from
 tvlistings.gracenote.com with intelligent caching and TVheadend integration.
 """
 
-__version__ = "2.0.0-dev16"
+__version__ = "2.0.0"
 __author__ = "th0ma7"
 __license__ = "GPL-3.0"
 

--- a/gracenote2epg/main.py
+++ b/gracenote2epg/main.py
@@ -340,30 +340,24 @@ def main():
         # Download and parse guide data
         with DataParser(cache_manager, tvh_client) as data_parser:
             # Download and parse guide blocks
-            guide_success = data_parser.download_and_parse_guide(
+            # download_and_parse_guide already warns on issues (no duplicate here).
+            data_parser.download_and_parse_guide(
                 grid_time_start=grid_time_start,
                 day_hours=day_hours,
                 config_manager=config_manager,
                 refresh_hours=refresh_hours,
             )
 
-            if not guide_success:
-                logging.warning("Guide download had issues, but continuing with available data")
-
             # Clean show cache now that we have parsed episodes
             active_series = data_parser.get_active_series_list()
             cache_manager.perform_show_cleanup(active_series)
 
-            # Download extended details if needed
+            # Download extended details if needed (the method warns on issues).
             if config_manager.needs_extended_download():
-                extended_success = data_parser.download_and_parse_series_details(
+                data_parser.download_and_parse_series_details(
                     workers=config_manager.get_download_workers(),
                     threshold=config_manager.get_download_threshold(),
                 )
-                if not extended_success:
-                    logging.warning(
-                        "Extended details download had issues, using basic descriptions"
-                    )
 
             # Generate XMLTV
             xmltv_generator = XmltvGenerator(


### PR DESCRIPTION
Finalize the **2.0.0** release (cut from dev16, validated on the NAS).

## Changes
- `__version__` → **`2.0.0`** (drop the `-dev16` pre-release suffix).
- Changelog `[2.0.0]` section **dated** (2026-06-17).
- README + installation.md install/version pins → **`2.0.0`** / **`v2.0.0`** (no more `--pre` needed — final release).
- De-duplicated the guide/extended-details *"had issues"* warning (it was logged by both the parser and `main`).

`make all` green (build + wheel/source install + 127 tests); black + flake8 (tightened) clean.

## After merge → tag & publish
```bash
git checkout main && git pull
git tag -a v2.0.0 -m "gracenote2epg 2.0.0"
git push origin v2.0.0
make build && python3 -m twine upload dist/*
```
(2.0.0 is a final release, so plain `pip install gracenote2epg[full]` will pick it up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
