### PR TITLE
fix: Python 3.8 compatibility (typing.Tuple in settings.py)

### DIFF
--- a/gracenote2epg/config/settings.py
+++ b/gracenote2epg/config/settings.py
@@ -8,7 +8,7 @@ and clean XML generation for gracenote2epg configurations.
 import logging
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Tuple
 
 
 class SettingsManager:
@@ -129,7 +129,7 @@ class SettingsManager:
         with open(config_file, "w", encoding="utf-8") as f:
             f.write(self.DEFAULT_CONFIG)
 
-    def parse_config_file(self, config_file: Path) -> tuple[Dict[str, Any], List[str], str]:
+    def parse_config_file(self, config_file: Path) -> Tuple[Dict[str, Any], List[str], str]:
         """
         Parse XML configuration file
 


### PR DESCRIPTION
The `v2.0.0` PyPI publish workflow **failed** on its Python 3.8 test job: `gracenote2epg --version` crashed at import.

Cause: `config/settings.py` used the builtin generic `tuple[...]` as a *runtime* return annotation — valid on 3.9+, but on 3.8 `tuple[...]` raises `TypeError: 'type' object is not subscriptable` at import. (Invisible locally/on the NAS — both run newer Python.)

Fix: use `Tuple` from `typing`. An AST scan confirms this was the **only** 3.8-incompatible annotation (no other builtin generics, no `X | Y` unions). Version stays **2.0.0** (it never reached PyPI). 127 tests green, black/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
